### PR TITLE
feat: add env label to metrics for prometheus

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -29,9 +29,11 @@ pub struct Synapse {
 pub struct Config {
     pub server: Server,
     pub synapse: Synapse,
+    pub env: String, // prd / stg / dev / biz
 }
 
 const SYNAPSE_URL_ENV: &str = "SYNAPSE_URL";
+const ENV_VAR: &str = "ENV";
 
 impl Config {
     pub fn new() -> Result<Self, ConfigError> {
@@ -43,12 +45,15 @@ impl Config {
             .add_source(
                 config::Environment::default()
                     .with_list_parse_key(SYNAPSE_URL_ENV)
+                    .with_list_parse_key(ENV_VAR)
                     .try_parsing(true)
-                    .separator("_"),
+                    .separator("_")
+                    .list_separator(" "),
             )
             .set_override_option("server.host", args.host)?
             .set_override_option("server.port", args.port)?
             .set_default("synapse.url", "https://synapse.decentraland.zone")?
+            .set_default("env", "dev")?
             .build()?;
 
         config.try_deserialize()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,13 +24,15 @@ pub fn run_service(data: Data<AppComponents>) -> Result<Server, std::io::Error> 
 
     init_telemetry();
 
+    log::debug!("App Config: {:?}", data.config);
+
     let server_host = data.config.server.host.clone();
     let server_port = data.config.server.port;
 
     let server = HttpServer::new(move || {
         App::new()
             .app_data(data.clone())
-            .wrap(initialize_metrics())
+            .wrap(initialize_metrics(data.config.env.clone()))
             .wrap(TracingLogger::default())
             .service(live)
             .service(health)

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,8 +1,13 @@
+use std::collections::HashMap;
+
 use actix_web_prom::{PrometheusMetrics, PrometheusMetricsBuilder};
 
-pub fn initialize_metrics() -> PrometheusMetrics {
+pub fn initialize_metrics(environment: String) -> PrometheusMetrics {
+    let mut map = HashMap::new();
+    map.insert(String::from("env"), environment);
     PrometheusMetricsBuilder::new("api")
         .endpoint("/metrics")
+        .const_labels(map)
         .build()
         .unwrap()
 }


### PR DESCRIPTION
This PR:
- add the env label according to [docs](https://playbooks.decentraland.systems/ops/metrics.html#naming-metrics)