### PR TITLE
feat: generalize AppComponents with dyn and traits

### DIFF
--- a/src/components/app.rs
+++ b/src/components/app.rs
@@ -29,8 +29,8 @@ pub struct App {
 }
 
 impl App {
-    pub async fn new(custom_config: Option<Config>) -> Arc<dyn AppComponents + Send + Sync> {
-        if let Err(_) = env_logger::try_init() {
+    pub async fn start_app(custom_config: Option<Config>) -> Arc<dyn AppComponents + Send + Sync> {
+        if env_logger::try_init().is_err() {
             log::debug!("Logger already init")
         }
 
@@ -50,7 +50,7 @@ impl App {
 
         if let Err(err) = redis.run().await {
             log::debug!("Error while connecting to redis: {:?}", err);
-            panic!("Unable connecting to redis {:?}", err)
+            panic!("Unable connecting to redis {err:?}")
         }
 
         // TODO: Should we refactor HealthComponent to avoid cloning structs?

--- a/src/components/app.rs
+++ b/src/components/app.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use super::health::HealthComponent;
-use super::synapse::SynapaseComponent;
+use super::synapse::SynapseComponent;
 use super::users_cache::UsersCacheComponent;
 use super::{
     configuration::Config, database::DatabaseComponent, health::Health, redis::RedisComponent,
@@ -15,7 +15,7 @@ use super::{
 
 pub trait AppComponents {
     fn get_health_component(&self) -> Arc<dyn HealthComponent>;
-    fn get_synapse_component(&self) -> Arc<dyn SynapaseComponent>;
+    fn get_synapse_component(&self) -> Arc<dyn SynapseComponent>;
     fn get_users_cache_component(&self) -> Arc<dyn UsersCacheComponent>;
     fn get_config(&self) -> &Config;
 }
@@ -76,7 +76,7 @@ impl AppComponents for App {
     fn get_config(&self) -> &Config {
         &self.config
     }
-    fn get_synapse_component(&self) -> Arc<dyn SynapaseComponent> {
+    fn get_synapse_component(&self) -> Arc<dyn SynapseComponent> {
         self.synapse.clone()
     }
     fn get_users_cache_component(&self) -> Arc<dyn UsersCacheComponent> {

--- a/src/components/health.rs
+++ b/src/components/health.rs
@@ -25,19 +25,26 @@ impl std::fmt::Debug for ComponentToCheck {
     }
 }
 
+#[async_trait]
+pub trait HealthComponent {
+    fn register_component(&mut self, component: Box<dyn Healthy + Send + Sync>, name: String);
+    async fn calculate_status(&self) -> HashMap<String, ComponentHealthStatus>;
+}
+
 #[derive(Default, Debug)]
-pub struct HealthComponent {
+pub struct Health {
     components_to_check: Vec<ComponentToCheck>,
 }
 
-impl HealthComponent {
-    pub fn register_component(&mut self, component: Box<dyn Healthy + Send + Sync>, name: String) {
+#[async_trait]
+impl HealthComponent for Health {
+    fn register_component(&mut self, component: Box<dyn Healthy + Send + Sync>, name: String) {
         self.components_to_check
             .push(ComponentToCheck { component, name });
     }
 
     #[tracing::instrument(name = "Calculate components status")]
-    pub async fn calculate_status(&self) -> HashMap<String, ComponentHealthStatus> {
+    async fn calculate_status(&self) -> HashMap<String, ComponentHealthStatus> {
         let mut result = HashMap::new();
 
         // TODO: Parallelize this checks

--- a/src/components/redis.rs
+++ b/src/components/redis.rs
@@ -54,7 +54,7 @@ impl RedisComponent for Redis {
                 }
                 Err(err) => {
                     log::debug!("Error on connecting to redis: {:?}", err);
-                    panic!("Unable to connect to redis {:?}", err)
+                    panic!("Unable to connect to redis {err:?}")
                 }
             };
 

--- a/src/components/synapse.rs
+++ b/src/components/synapse.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 
 #[async_trait::async_trait]
-pub trait SynapaseComponent {
+pub trait SynapseComponent {
     async fn get_version(&self) -> Result<VersionResponse, String>;
 }
 
@@ -31,7 +31,7 @@ impl Synapse {
 }
 
 #[async_trait::async_trait]
-impl SynapaseComponent for Synapse {
+impl SynapseComponent for Synapse {
     async fn get_version(&self) -> Result<VersionResponse, String> {
         let version_url = format!("{}{}", self.synapse_url, VERSION_URI);
         let result: Result<VersionResponse, String> = match reqwest::get(version_url).await {

--- a/src/components/synapse.rs
+++ b/src/components/synapse.rs
@@ -2,8 +2,13 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
+#[async_trait::async_trait]
+pub trait SynapaseComponent {
+    async fn get_version(&self) -> Result<VersionResponse, String>;
+}
+
 #[derive(Debug)]
-pub struct SynapseComponent {
+pub struct Synapse {
     synapse_url: String,
 }
 
@@ -15,7 +20,7 @@ pub struct VersionResponse {
     unstable_features: HashMap<String, bool>,
 }
 
-impl SynapseComponent {
+impl Synapse {
     pub fn new(url: String) -> Self {
         if url.is_empty() {
             panic!("missing synapse URL")
@@ -23,8 +28,11 @@ impl SynapseComponent {
 
         Self { synapse_url: url }
     }
+}
 
-    pub async fn get_version(&self) -> Result<VersionResponse, String> {
+#[async_trait::async_trait]
+impl SynapaseComponent for Synapse {
+    async fn get_version(&self) -> Result<VersionResponse, String> {
         let version_url = format!("{}{}", self.synapse_url, VERSION_URI);
         let result: Result<VersionResponse, String> = match reqwest::get(version_url).await {
             Ok(response) => match response.json::<VersionResponse>().await {

--- a/src/components/users_cache.rs
+++ b/src/components/users_cache.rs
@@ -49,15 +49,12 @@ impl<T: RedisComponent + std::fmt::Debug + Sync + Send> UsersCacheComponent for 
         let con = self.redis_component.get_async_connection().await;
 
         if con.is_none() {
-            let error = format!(
-                "Couldn't cache user {}, redis has no connection available",
-                user_id
-            );
+            let error = format!("Couldn't cache user {user_id}, redis has no connection available");
             log::error!("{}", error);
             return Err(error);
         }
 
-        let key = hash_with_key(&token, &self.hashing_key);
+        let key = hash_with_key(token, &self.hashing_key);
 
         let mut connection = con.unwrap();
 
@@ -65,7 +62,7 @@ impl<T: RedisComponent + std::fmt::Debug + Sync + Send> UsersCacheComponent for 
             .arg(&[key.clone(), user_id.to_string()])
             .arg(&[
                 "EX".to_string(),
-                (custom_exipry_time.unwrap_or_else(|| DEFAULT_EXPIRATION_TIME_SECONDS)).to_string(),
+                (custom_exipry_time.unwrap_or(DEFAULT_EXPIRATION_TIME_SECONDS)).to_string(),
             ])
             .query_async::<_, ()>(&mut connection)
             .await;
@@ -73,8 +70,8 @@ impl<T: RedisComponent + std::fmt::Debug + Sync + Send> UsersCacheComponent for 
         match set_res {
             Ok(_) => Ok(()),
             Err(err) => {
-                let error = format!("Couldn't cache user {}", err);
-                log::error!("{}", error);
+                let error = format!("Couldn't cache user {err}");
+                log::error!("{error}");
                 Err(error)
             }
         }
@@ -88,7 +85,7 @@ impl<T: RedisComponent + std::fmt::Debug + Sync + Send> UsersCacheComponent for 
             return Err("Couldn't obtain user redis has no connection available".to_string());
         }
 
-        let key = hash_with_key(&token, &self.hashing_key);
+        let key = hash_with_key(token, &self.hashing_key);
 
         let mut connection = con.unwrap();
         let res: RedisResult<String> = cmd("GET").arg(&[key]).query_async(&mut connection).await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ pub fn run_service(data: AppData) -> Result<Server, std::io::Error> {
 }
 
 pub async fn get_app_data(custom_config: Option<Config>) -> AppData {
-    let app_data = App::new(custom_config).await;
+    let app_data = App::start_app(custom_config).await;
     Data::from(app_data)
 }
 

--- a/src/routes/health/handlers.rs
+++ b/src/routes/health/handlers.rs
@@ -1,11 +1,11 @@
 use std::collections::HashMap;
 
-use actix_web::{get, http::StatusCode, web::Data, HttpResponse};
+use actix_web::{get, http::StatusCode, HttpResponse};
 
 use serde::Serialize;
 
 use super::consts::{FAIL, FAILED_STATUS, SUCCESSFUL_STATUS};
-use crate::{components::app::AppComponents, routes::health::consts::MIME};
+use crate::{routes::health::consts::MIME, AppData};
 
 #[derive(Debug, Default, Serialize)]
 struct HealthStatus {
@@ -23,10 +23,10 @@ struct ReadinessResponse {
     status: String,
 }
 
-pub async fn is_app_healthy(app_data: Data<AppComponents>) -> HttpResponse {
+pub async fn is_app_healthy(app_data: AppData) -> HttpResponse {
     let mut result = HealthStatus::default();
 
-    result.checks = app_data.health.calculate_status().await;
+    result.checks = app_data.get_health_component().calculate_status().await;
     let is_ready = !result
         .checks
         .values()
@@ -64,7 +64,7 @@ pub async fn is_app_healthy(app_data: Data<AppComponents>) -> HttpResponse {
  */
 
 #[get("/health/ready")]
-pub async fn health(app_data: Data<AppComponents>) -> HttpResponse {
+pub async fn health(app_data: AppData) -> HttpResponse {
     is_app_healthy(app_data).await
 }
 
@@ -79,11 +79,11 @@ pub async fn health(app_data: Data<AppComponents>) -> HttpResponse {
  * res (200) for the startup probe.
  */
 #[get("/health/startup")]
-pub async fn startup(app_data: Data<AppComponents>) -> HttpResponse {
+pub async fn startup(app_data: AppData) -> HttpResponse {
     is_app_healthy(app_data).await
 }
 
 #[get("/health/live")]
-pub async fn live(_app_data: Data<AppComponents>) -> HttpResponse {
+pub async fn live(_app_data: AppData) -> HttpResponse {
     HttpResponse::Ok().json("alive")
 }

--- a/src/routes/synapse/handlers.rs
+++ b/src/routes/synapse/handlers.rs
@@ -1,10 +1,10 @@
-use crate::components::app::AppComponents;
+use actix_web::{get, HttpResponse};
 
-use actix_web::{get, web::Data, HttpResponse};
+use crate::AppData;
 
 #[get("/_matrix/client/versions")]
-pub async fn version(app_data: Data<AppComponents>) -> HttpResponse {
-    let version_response = app_data.synapse.get_version().await;
+pub async fn version(app_data: AppData) -> HttpResponse {
+    let version_response = app_data.get_synapse_component().get_version().await;
 
     match version_response {
         Ok(ok_response) => HttpResponse::Ok().json(ok_response),

--- a/tests/components/users_cache.rs
+++ b/tests/components/users_cache.rs
@@ -6,14 +6,14 @@ mod tests {
     use social_service::components::{
         configuration::Redis as RedisConfig,
         redis::{Redis, RedisComponent},
-        users_cache::UsersCacheComponent,
+        users_cache::{UsersCache, UsersCacheComponent},
     };
 
     use actix_rt::time::sleep;
 
     const TEST_KEY: &str = "TEST KEY";
 
-    async fn create_users_cache_component() -> UsersCacheComponent<Redis> {
+    async fn create_users_cache_component() -> UsersCache<Redis> {
         let mut redis = Redis::new(&RedisConfig {
             host: "0.0.0.0:6379".to_string(),
         });
@@ -26,7 +26,7 @@ mod tests {
             _ => {}
         }
 
-        UsersCacheComponent::new(redis, TEST_KEY.to_string())
+        UsersCache::new(redis, TEST_KEY.to_string())
     }
 
     #[actix_web::test]


### PR DESCRIPTION
This PR:
- changes `AppComponents` struct for `App` struct 
- creates a trait for `AppComponents` with getters for components
- `App` implements `AppComponents`
- creates traits for the components that need it 
- Actix Data is now `Data(dyn  AppComponents)` so that it's easier for testing and mocking