### PR TITLE
feat: refactor to generalize AppComponents 

### DIFF
--- a/src/components/app.rs
+++ b/src/components/app.rs
@@ -59,7 +59,7 @@ pub async fn new_app<
 
     if let Err(err) = redis.run().await {
         log::debug!("Error while connecting to redis: {:?}", err);
-        panic!("Unable connecting to redis {:?}", err)
+        panic!("Unable connecting to redis {err:?}")
     }
 
     // TODO: Should we refactor HealthComponent to avoid cloning structs?

--- a/src/components/app.rs
+++ b/src/components/app.rs
@@ -16,7 +16,7 @@ pub struct AppComponents<H: HealthComponent, S: SynapseComponent> {
 }
 
 impl<H: HealthComponent, S: SynapseComponent> AppComponents<H, S> {
-    fn new(
+    pub fn new(
         health: H,
         synapse: S,
         config: Config,
@@ -39,6 +39,10 @@ pub async fn new_app<
 >(
     custom_config: Option<Config>,
 ) -> AppComponents<H, S> {
+    if env_logger::try_init().is_err() {
+        log::error!("failed when trying to initialize logger")
+    }
+
     let config =
         custom_config.unwrap_or_else(|| Config::new().expect("Couldn't read the configuration"));
 

--- a/src/components/app.rs
+++ b/src/components/app.rs
@@ -1,58 +1,103 @@
-use super::{
-    configuration::Config, database::DatabaseComponent, health::HealthComponent,
-    redis::RedisComponent, synapse::SynapseComponent,
-};
+use std::sync::Arc;
+
+use super::health::HealthComponent;
+use super::synapse::SynapseComponent;
+use super::{configuration::Config, database::DatabaseComponent, redis::RedisComponent};
 
 use super::{
     redis::Redis,
     users_cache::{self, UsersCacheComponent},
 };
 
-pub struct AppComponents {
-    pub health: HealthComponent,
-    pub synapse: SynapseComponent,
-    pub config: Config,
-    pub db: DatabaseComponent,
-    pub user_cache: UsersCacheComponent<Redis>,
+pub trait IAppComponents<H: HealthComponent, S: SynapseComponent> {
+    fn new(
+        health_component: H,
+        synapse_component: S,
+        config: Config,
+        db: DatabaseComponent,
+        users_cache: UsersCacheComponent<Redis>,
+    ) -> Self
+    where
+        Self: Sized;
+    fn get_health_component(&self) -> &H;
+    fn get_config_component(&self) -> &Config;
+    fn get_synapse_component(&self) -> &S;
 }
 
-impl AppComponents {
-    pub async fn new(custom_config: Option<Config>) -> Self {
-        if let Err(_) = env_logger::try_init() {
-            log::debug!("Logger already init")
-        }
+pub struct AppComponents<H: HealthComponent, S: SynapseComponent> {
+    pub health: H,
+    pub synapse: S,
+    pub config: Config,
+    pub db: DatabaseComponent,
+    pub users_cache: UsersCacheComponent<Redis>,
+}
 
-        // Initialize components
-        let config = custom_config
-            .unwrap_or_else(|| Config::new().expect("Couldn't read the configuration"));
-
-        let mut health = HealthComponent::default();
-        let synapse = SynapseComponent::new(config.synapse.url.clone());
-        let mut db = DatabaseComponent::new(&config.db);
-        let mut redis = Redis::new(&config.redis);
-
-        if let Err(err) = db.run().await {
-            log::debug!("Error on running the DB: {:?}", err);
-            panic!("Unable to run the DB")
-        }
-
-        if let Err(err) = redis.run().await {
-            log::debug!("Error while connecting to redis: {:?}", err);
-            panic!("Unable connecting to redis {:?}", err)
-        }
-
-        // TODO: Should we refactor HealthComponent to avoid cloning structs?
-        health.register_component(Box::new(db.clone()), "database".to_string());
-        health.register_component(Box::new(redis.clone()), "redis".to_string());
-        let users_cache_instance =
-            users_cache::UsersCacheComponent::new(redis, config.cache_hashing_key.clone());
-
+impl<H: HealthComponent, S: SynapseComponent> IAppComponents<H, S> for AppComponents<H, S> {
+    fn new(
+        health: H,
+        synapse: S,
+        config: Config,
+        db: DatabaseComponent,
+        users_cache: UsersCacheComponent<Redis>,
+    ) -> Self
+    where
+        Self: Sized,
+    {
         Self {
-            config,
             health,
             synapse,
+            config,
             db,
-            user_cache: users_cache_instance,
+            users_cache,
         }
     }
+    fn get_health_component(&self) -> &H {
+        &self.health
+    }
+    fn get_config_component(&self) -> &Config {
+        &self.config
+    }
+    fn get_synapse_component(&self) -> &S {
+        &self.synapse
+    }
+}
+
+pub async fn new_app<
+    H: HealthComponent + Default + Send + Sync + 'static,
+    S: SynapseComponent + Send + Sync + 'static,
+>(
+    custom_config: Option<Config>,
+) -> Arc<dyn IAppComponents<H, S> + Send + Sync> {
+    let config =
+        custom_config.unwrap_or_else(|| Config::new().expect("Couldn't read the configuration"));
+
+    let mut health = H::default();
+    let synapse = S::new(config.synapse.url.clone());
+
+    let mut db = DatabaseComponent::new(&config.db);
+    let mut redis = Redis::new(&config.redis);
+
+    if let Err(err) = db.run().await {
+        log::debug!("Error on running the DB: {:?}", err);
+        panic!("Unable to run the DB")
+    }
+
+    if let Err(err) = redis.run().await {
+        log::debug!("Error while connecting to redis: {:?}", err);
+        panic!("Unable connecting to redis {:?}", err)
+    }
+
+    // TODO: Should we refactor HealthComponent to avoid cloning structs?
+    health.register_component(Box::new(db.clone()), "database".to_string());
+    health.register_component(Box::new(redis.clone()), "redis".to_string());
+    let users_cache_instance =
+        users_cache::UsersCacheComponent::new(redis, config.cache_hashing_key.clone());
+
+    Arc::new(AppComponents::new(
+        health,
+        synapse,
+        config,
+        db,
+        users_cache_instance,
+    ))
 }

--- a/src/components/database.rs
+++ b/src/components/database.rs
@@ -101,12 +101,9 @@ impl Healthy for DatabaseComponent {
             .fetch_one(DatabaseComponent::get_connection(&self.db_connection))
             .await
         {
-            Ok(result) => {
-                match result.try_get::<DateTime<chrono::Utc>, &str>("current_timestamp") {
-                    Ok(_) => true,
-                    Err(_) => false,
-                }
-            }
+            Ok(result) => result
+                .try_get::<DateTime<chrono::Utc>, &str>("current_timestamp")
+                .is_ok(),
             Err(_) => false,
         }
     }

--- a/src/components/health.rs
+++ b/src/components/health.rs
@@ -25,19 +25,26 @@ impl std::fmt::Debug for ComponentToCheck {
     }
 }
 
+#[async_trait::async_trait]
+pub trait HealthComponent {
+    fn register_component(&mut self, component: Box<dyn Healthy + Send + Sync>, name: String);
+    async fn calculate_status(&self) -> HashMap<String, ComponentHealthStatus>;
+}
+
 #[derive(Default, Debug)]
-pub struct HealthComponent {
+pub struct Health {
     components_to_check: Vec<ComponentToCheck>,
 }
 
-impl HealthComponent {
-    pub fn register_component(&mut self, component: Box<dyn Healthy + Send + Sync>, name: String) {
+#[async_trait::async_trait]
+impl HealthComponent for Health {
+    fn register_component(&mut self, component: Box<dyn Healthy + Send + Sync>, name: String) {
         self.components_to_check
             .push(ComponentToCheck { component, name });
     }
 
     #[tracing::instrument(name = "Calculate components status")]
-    pub async fn calculate_status(&self) -> HashMap<String, ComponentHealthStatus> {
+    async fn calculate_status(&self) -> HashMap<String, ComponentHealthStatus> {
         let mut result = HashMap::new();
 
         // TODO: Parallelize this checks

--- a/src/components/health.rs
+++ b/src/components/health.rs
@@ -12,9 +12,9 @@ pub trait Healthy {
     async fn is_healthy(&self) -> bool;
 }
 
-struct ComponentToCheck {
-    component: Box<dyn Healthy + Send + Sync>,
-    name: String,
+pub struct ComponentToCheck {
+    pub component: Box<dyn Healthy + Send + Sync>,
+    pub name: String,
 }
 
 impl std::fmt::Debug for ComponentToCheck {

--- a/src/components/redis.rs
+++ b/src/components/redis.rs
@@ -54,7 +54,7 @@ impl RedisComponent for Redis {
                 }
                 Err(err) => {
                     log::debug!("Error on connecting to redis: {:?}", err);
-                    panic!("Unable to connect to redis {:?}", err)
+                    panic!("Unable to connect to redis {err:?}")
                 }
             };
 

--- a/src/components/synapse.rs
+++ b/src/components/synapse.rs
@@ -2,8 +2,16 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
+#[async_trait::async_trait]
+pub trait SynapseComponent {
+    fn new(url: String) -> Self
+    where
+        Self: Sized;
+    async fn get_version(&self) -> Result<VersionResponse, String>;
+}
+
 #[derive(Debug)]
-pub struct SynapseComponent {
+pub struct Synapse {
     synapse_url: String,
 }
 
@@ -15,16 +23,12 @@ pub struct VersionResponse {
     unstable_features: HashMap<String, bool>,
 }
 
-impl SynapseComponent {
-    pub fn new(url: String) -> Self {
-        if url.is_empty() {
-            panic!("missing synapse URL")
-        }
-
+#[async_trait::async_trait]
+impl SynapseComponent for Synapse {
+    fn new(url: String) -> Self {
         Self { synapse_url: url }
     }
-
-    pub async fn get_version(&self) -> Result<VersionResponse, String> {
+    async fn get_version(&self) -> Result<VersionResponse, String> {
         let version_url = format!("{}{}", self.synapse_url, VERSION_URI);
         let result: Result<VersionResponse, String> = match reqwest::get(version_url).await {
             Ok(response) => match response.json::<VersionResponse>().await {

--- a/src/components/synapse.rs
+++ b/src/components/synapse.rs
@@ -19,8 +19,8 @@ pub const VERSION_URI: &str = "/_matrix/client/versions";
 
 #[derive(Deserialize, Serialize)]
 pub struct VersionResponse {
-    versions: Vec<String>,
-    unstable_features: HashMap<String, bool>,
+    pub versions: Vec<String>,
+    pub unstable_features: HashMap<String, bool>,
 }
 
 #[async_trait::async_trait]

--- a/src/components/users_cache.rs
+++ b/src/components/users_cache.rs
@@ -1,6 +1,4 @@
-use std::error::Error;
-
-use deadpool_redis::redis::{cmd, RedisError, RedisResult};
+use deadpool_redis::redis::{cmd, RedisResult};
 
 use crate::utils::encrypt_string::hash_with_key;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,24 +7,34 @@ mod utils;
 
 use actix_web::body::MessageBody;
 use actix_web::dev::{Server, ServiceFactory};
+use actix_web::web;
 use actix_web::{web::Data, App, HttpServer};
+use components::app::{new_app, IAppComponents};
+use components::health::{Health, HealthComponent};
+use components::synapse::{Synapse, SynapseComponent};
 use tracing_actix_web::TracingLogger;
 
-use components::{app::AppComponents, configuration::Config, tracing::init_telemetry};
+use components::{configuration::Config, tracing::init_telemetry};
 use metrics::initialize_metrics;
 use middlewares::metrics_token::CheckMetricsToken;
 use routes::{
-    health::handlers::{health, live},
+    health::handlers::{health, live, startup},
     synapse::handlers::version,
 };
 
-pub fn run_service(data: Data<AppComponents>) -> Result<Server, std::io::Error> {
+// pub type AppData<H, S> = Data<AppComponents<H, S>>;
+
+pub type AppData<H, S> = Data<dyn IAppComponents<H, S> + Send + Sync>;
+
+pub fn run_service(data: AppData<Health, Synapse>) -> Result<Server, std::io::Error> {
     init_telemetry();
 
-    log::debug!("App Config: {:?}", data.config);
+    let app_config = data.get_config_component();
 
-    let server_host = data.config.server.host.clone();
-    let server_port = data.config.server.port;
+    log::debug!("App Config: {:?}", app_config);
+
+    let server_host = app_config.server.host.clone();
+    let server_port = app_config.server.port;
 
     let server = HttpServer::new(move || get_app_router(&data))
         .bind((server_host, server_port))?
@@ -33,13 +43,13 @@ pub fn run_service(data: Data<AppComponents>) -> Result<Server, std::io::Error> 
     Ok(server)
 }
 
-pub async fn get_app_data(custom_config: Option<Config>) -> Data<AppComponents> {
-    let app_data = AppComponents::new(custom_config).await;
-    Data::new(app_data)
+pub async fn get_app_data(custom_config: Option<Config>) -> AppData<Health, Synapse> {
+    let app = new_app(custom_config).await;
+    Data::from(app)
 }
 
-pub fn get_app_router(
-    data: &Data<AppComponents>,
+pub fn get_app_router<H: HealthComponent + 'static, S: SynapseComponent + 'static>(
+    data: &AppData<H, S>,
 ) -> App<
     impl ServiceFactory<
         actix_web::dev::ServiceRequest,
@@ -49,16 +59,18 @@ pub fn get_app_router(
         InitError = (),
     >,
 > {
+    let app_config = data.get_config_component();
     App::new()
         .app_data(data.clone())
         .wrap(TracingLogger::default())
-        .wrap(initialize_metrics(data.config.env.clone()))
+        .wrap(initialize_metrics(app_config.env.clone()))
         .wrap(CheckMetricsToken::new(
-            data.config.wkc_metrics_bearer_token.clone(),
+            app_config.wkc_metrics_bearer_token.clone(),
         ))
-        .service(live)
-        .service(health)
-        .service(version)
+        .route("/_matrix/client/versions", web::get().to(version::<H, S>))
+        .route("/health/live", web::get().to(live))
+        .route("/health/ready", web::get().to(health::<H, S>))
+        .route("/health/startup", web::get().to(startup::<H, S>))
 }
 
 fn generate_uuid_v4() -> String {

--- a/src/routes/health/handlers.rs
+++ b/src/routes/health/handlers.rs
@@ -32,9 +32,7 @@ pub async fn is_app_healthy<H: HealthComponent, S: SynapseComponent>(
 ) -> HttpResponse {
     let mut result = HealthStatus::default();
 
-    let health_component = app_data.get_health_component();
-
-    result.checks = health_component.calculate_status().await;
+    result.checks = app_data.health.calculate_status().await;
     let is_ready = !result
         .checks
         .values()

--- a/src/routes/synapse/handlers.rs
+++ b/src/routes/synapse/handlers.rs
@@ -1,10 +1,15 @@
-use crate::components::app::AppComponents;
+use crate::{
+    components::{health::HealthComponent, synapse::SynapseComponent},
+    AppData,
+};
 
-use actix_web::{get, web::Data, HttpResponse};
+use actix_web::HttpResponse;
 
-#[get("/_matrix/client/versions")]
-pub async fn version(app_data: Data<AppComponents>) -> HttpResponse {
-    let version_response = app_data.synapse.get_version().await;
+pub async fn version<H: HealthComponent, S: SynapseComponent>(
+    app_data: AppData<H, S>,
+) -> HttpResponse {
+    let synapse_component = app_data.get_synapse_component();
+    let version_response = synapse_component.get_version().await;
 
     match version_response {
         Ok(ok_response) => HttpResponse::Ok().json(ok_response),

--- a/src/routes/synapse/handlers.rs
+++ b/src/routes/synapse/handlers.rs
@@ -8,8 +8,7 @@ use actix_web::HttpResponse;
 pub async fn version<H: HealthComponent, S: SynapseComponent>(
     app_data: AppData<H, S>,
 ) -> HttpResponse {
-    let synapse_component = app_data.get_synapse_component();
-    let version_response = synapse_component.get_version().await;
+    let version_response = app_data.synapse.get_version().await;
 
     match version_response {
         Ok(ok_response) => HttpResponse::Ok().json(ok_response),

--- a/tests/helpers/server.rs
+++ b/tests/helpers/server.rs
@@ -2,70 +2,114 @@ use std::collections::HashMap;
 
 use actix_web::{body::MessageBody, dev::ServiceFactory, web::Data, App};
 use async_trait::async_trait;
-use mockall::mock;
+use mockall::automock;
 use social_service::{
     components::{
-        app::new_app,
+        app::AppComponents,
         configuration::{Config, Database},
-        health::{HealthComponent, Healthy},
+        database::DatabaseComponent,
+        health::{ComponentToCheck, HealthComponent, Healthy},
+        redis::{Redis, RedisComponent},
         synapse::{SynapseComponent, VersionResponse},
+        users_cache,
     },
     get_app_data, get_app_router,
     routes::health::handlers::ComponentHealthStatus,
+    AppData,
 };
 use sqlx::{Connection, Executor, PgConnection, PgPool};
 
-mock! {
-    #[derive(Debug)]
-    pub Health {}
+pub struct OptionalComponents<H: HealthComponent, S: SynapseComponent> {
+    pub health: Option<H>,
+    pub synapse: Option<S>,
+}
+#[derive(Debug)]
+pub struct Health {
+    components_to_check: Vec<ComponentToCheck>,
+}
 
-    #[async_trait]
-    impl HealthComponent for Health {
-        fn register_component(&mut self, component: Box<dyn Healthy + Send + Sync>, name: String) {
-            self.components_to_check
+#[automock]
+#[async_trait]
+impl HealthComponent for Health {
+    fn register_component(&mut self, component: Box<dyn Healthy + Send + Sync>, name: String) {
+        self.components_to_check
             .push(ComponentToCheck { component, name });
-        }
-        async fn calculate_status(&self) -> HashMap<String, ComponentHealthStatus> {
-            HashMap::new()
-        }
+    }
+    async fn calculate_status(&self) -> HashMap<String, ComponentHealthStatus> {
+        HashMap::new()
     }
 }
 
-mock! {
-    #[derive(Debug)]
-    pub Synapse {}
-
-    #[async_trait]
-    impl SynapseComponent for Synapse {
-        fn new(url: String) -> Self {
-            Self {
-                url
-            }
-        }
-        async fn get_version(&self) -> Result<VersionResponse, String> {
-            Ok(VersionResponse{
-                versions: Vec::new(),
-                unstable_features: HashMap::new()
-            })
-        }
-    }
-
+#[derive(Debug)]
+pub struct Synapse {
+    pub synapse_url: String,
 }
 
-pub async fn get_testing_app(
+#[automock]
+#[async_trait]
+impl SynapseComponent for Synapse {
+    fn new(url: String) -> Self {
+        Self { synapse_url: url }
+    }
+    async fn get_version(&self) -> Result<VersionResponse, String> {
+        Ok(VersionResponse {
+            versions: Vec::new(),
+            unstable_features: HashMap::new(),
+        })
+    }
+}
+
+pub async fn get_testing_app_data<
+    H: HealthComponent + Default + Send + Sync + 'static,
+    S: SynapseComponent + Send + Sync + 'static,
+>(
     config: Config,
-) -> App<
-    impl ServiceFactory<
-        actix_web::dev::ServiceRequest,
-        Config = (),
-        Response = actix_web::dev::ServiceResponse<impl MessageBody>,
-        Error = actix_web::Error,
-        InitError = (),
-    >,
-> {
+    components: OptionalComponents<H, S>,
+) -> AppData<H, S> {
     create_test_db(&config.db).await;
-    let app_data = new_app::<MockHealth, MockSynapse>(Some(config)).await;
-    get_app_router(&Data::new(app_data))
+    Data::new(new_testing_app(Some(config), components).await)
+}
+
+pub async fn new_testing_app<
+    H: HealthComponent + Default + Send + Sync + 'static,
+    S: SynapseComponent + Send + Sync + 'static,
+>(
+    custom_config: Option<Config>,
+    components: OptionalComponents<H, S>,
+) -> AppComponents<H, S> {
+    let config =
+        custom_config.unwrap_or_else(|| Config::new().expect("Couldn't read the configuration"));
+
+    let mut health = H::default();
+    if let Some(h) = components.health {
+        health = h
+    }
+
+    let mut synapse = S::new(config.synapse.url.clone());
+    if let Some(s) = components.synapse {
+        synapse = s
+    }
+
+    let mut db = DatabaseComponent::new(&config.db);
+    let mut redis = Redis::new(&config.redis);
+
+    if let Err(err) = db.run().await {
+        log::debug!("Error on running the DB: {:?}", err);
+        panic!("Unable to run the DB")
+    }
+
+    if let Err(err) = redis.run().await {
+        log::debug!("Error while connecting to redis: {:?}", err);
+        panic!("Unable connecting to redis {:?}", err)
+    }
+
+    // TODO: Should we refactor HealthComponent to avoid cloning structs?
+    health.register_component(Box::new(db.clone()), "database".to_string());
+    health.register_component(Box::new(redis.clone()), "redis".to_string());
+    let users_cache_instance =
+        users_cache::UsersCacheComponent::new(redis, config.cache_hashing_key.clone());
+
+    AppComponents::new(health, synapse, config, db, users_cache_instance)
 }
 
 pub fn get_configuration() -> Config {

--- a/tests/helpers/server.rs
+++ b/tests/helpers/server.rs
@@ -12,7 +12,6 @@ use social_service::{
     },
     get_app_data, get_app_router,
     routes::health::handlers::ComponentHealthStatus,
-    AppData,
 };
 use sqlx::{Connection, Executor, PgConnection, PgPool};
 
@@ -65,8 +64,8 @@ pub async fn get_testing_app(
     >,
 > {
     create_test_db(&config.db).await;
-    let app_data = Data::from(new_app::<MockHealth, MockSynapse>(Some(config)).await);
-    get_app_router(&app_data)
+    let app_data = new_app::<MockHealth, MockSynapse>(Some(config)).await;
+    get_app_router(&Data::new(app_data))
 }
 
 pub fn get_configuration() -> Config {

--- a/tests/routes/health.rs
+++ b/tests/routes/health.rs
@@ -1,19 +1,42 @@
 #[cfg(test)]
 mod tests {
 
-    use crate::helpers::server::{get_app, get_configuration};
+    use std::collections::HashMap;
+
+    use crate::helpers::server::{
+        get_configuration, get_testing_app_data, MockHealth, OptionalComponents,
+    };
     use actix_web::test;
+    use social_service::{components::synapse::Synapse, get_app_router};
 
     #[actix_web::test]
     async fn test_index_get() {
         let config = get_configuration();
 
-        let app = test::init_service(get_app(config).await).await;
+        // Mocking Example for Health component
+        let mut health = MockHealth::default();
+
+        health.expect_register_component().times(2).return_const(());
+        health
+            .expect_calculate_status()
+            .once()
+            .returning(|| HashMap::new());
+
+        let components = OptionalComponents {
+            health: Some(health),
+            synapse: None,
+        };
+
+        let app_data = get_testing_app_data::<MockHealth, Synapse>(config, components).await;
+
+        let app = get_app_router(&app_data);
+
+        let app = test::init_service(app).await;
 
         let req = test::TestRequest::get().uri("/health/ready").to_request();
 
         let response = test::call_service(&app, req).await;
 
-        assert!(response.status().is_success())
+        assert!(response.status().is_success());
     }
 }


### PR DESCRIPTION
This PR: 
- changes `AppComponents` to receive generics for components
- routes and handlers declaration changed due to generics when a route expects `AppData` in its handler. 

It's a variant of PR #75 and closes #74 