### PR TITLE
tests: try `faux` crate for mocking and testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -612,6 +612,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0dd3cd20dc6b5a876612a6e5accfe7f3dd883db6d07acfbf14c128f61550dfa"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a784d2ccaf7c98501746bf0be29b2022ba41fd62a2e622af997a03e9f972859f"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -670,12 +705,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "difflib"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
-
-[[package]]
 name = "digest"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -717,12 +746,6 @@ name = "dotenvy"
 version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03d8c417d7a8cb362e0c37e5d815f5eb7c37f79ff93707329d5a194e42e54ca0"
-
-[[package]]
-name = "downcast"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "either"
@@ -768,6 +791,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "faux"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c3b5e56a69ca67c241191cd9d484e14fb0fe89f5e539c2e8448eafd1f65c1f0"
+dependencies = [
+ "faux_macros",
+ "paste",
+]
+
+[[package]]
+name = "faux_macros"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35c9bb4a2c13ffb3a93a39902aaf4e7190a1706a4779b6db0449aee433d26c4a"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "uuid 0.8.2",
+]
+
+[[package]]
 name = "flate2"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -775,15 +821,6 @@ checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
-]
-
-[[package]]
-name = "float-cmp"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -815,12 +852,6 @@ checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "fragile"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "futures"
@@ -1134,6 +1165,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1346,33 +1383,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mockall"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50e4a1c770583dac7ab5e2f6c139153b783a53a1bbee9729613f193e59828326"
-dependencies = [
- "cfg-if",
- "downcast",
- "fragile",
- "lazy_static",
- "mockall_derive",
- "predicates",
- "predicates-tree",
-]
-
-[[package]]
-name = "mockall_derive"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "832663583d5fa284ca8810bf7015e46c9fff9622d3cf34bd1eea5003fec06dd0"
-dependencies = [
- "cfg-if",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "native-tls"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1399,12 +1409,6 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
-
-[[package]]
-name = "normalize-line-endings"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "nu-ansi-term"
@@ -1725,36 +1729,6 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
-
-[[package]]
-name = "predicates"
-version = "2.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f54fc5dc63ed3bbf19494623db4f3af16842c0d975818e469022d09e53f0aa05"
-dependencies = [
- "difflib",
- "float-cmp",
- "itertools",
- "normalize-line-endings",
- "predicates-core",
- "regex",
-]
-
-[[package]]
-name = "predicates-core"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f883590242d3c6fc5bf50299011695fa6590c2c70eac95ee1bdb9a733ad1a2"
-
-[[package]]
-name = "predicates-tree"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54ff541861505aabf6ea722d2131ee980b8276e10a1297b94e896dd8b621850d"
-dependencies = [
- "predicates-core",
- "termtree",
-]
 
 [[package]]
 name = "proc-macro-error"
@@ -2192,11 +2166,11 @@ dependencies = [
  "config",
  "deadpool-redis",
  "env_logger",
+ "faux",
  "futures-util",
  "hex",
  "hmac",
  "log",
- "mockall",
  "opentelemetry",
  "opentelemetry-jaeger",
  "qstring",
@@ -2211,7 +2185,7 @@ dependencies = [
  "tracing-log",
  "tracing-opentelemetry",
  "tracing-subscriber",
- "uuid",
+ "uuid 1.2.2",
 ]
 
 [[package]]
@@ -2293,7 +2267,7 @@ dependencies = [
  "thiserror",
  "tokio-stream",
  "url",
- "uuid",
+ "uuid 1.2.2",
  "whoami",
 ]
 
@@ -2384,12 +2358,6 @@ checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "termtree"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95059e91184749cb66be6dc994f67f182b6d897cb3df74a5bf66b5e709295fd8"
 
 [[package]]
 name = "textwrap"
@@ -2592,7 +2560,7 @@ dependencies = [
  "actix-web",
  "pin-project",
  "tracing",
- "uuid",
+ "uuid 1.2.2",
 ]
 
 [[package]]
@@ -2742,6 +2710,15 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+]
+
+[[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,5 +35,5 @@ hex = "0.4.3"
 
 [dev-dependencies]
 serial_test = "0.9.0"
-mockall = "0.11.0"
 actix-rt = "2.7.0"
+faux = "0.1.9"

--- a/src/components/redis.rs
+++ b/src/components/redis.rs
@@ -1,17 +1,19 @@
 use async_trait::async_trait;
 use deadpool_redis::{
-    redis::{cmd, RedisError, RedisResult},
+    redis::{cmd, RedisResult},
     Config, Connection, Pool, Runtime,
 };
 
 use super::{configuration::Redis as RedisConfig, health::Healthy};
 
+#[cfg_attr(test, faux::create)]
 #[derive(Clone)]
 pub struct Redis {
     redis_host: String,
     pub pool: Option<Pool>,
 }
 
+#[cfg_attr(test, faux::methods)]
 impl std::fmt::Debug for Redis {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Redis")
@@ -21,51 +23,34 @@ impl std::fmt::Debug for Redis {
     }
 }
 
-#[async_trait]
-pub trait RedisComponent {
-    async fn stop(&mut self);
-    async fn run(&mut self) -> Result<(), RedisError>;
-    async fn get_async_connection(&mut self) -> Option<Connection>;
-}
-
+#[cfg_attr(test, faux::methods)]
 impl Redis {
-    pub fn new(config: &RedisConfig) -> Self {
-        Self {
+    pub fn new_and_run(config: &RedisConfig) -> Self {
+        let mut redis = Self {
             redis_host: config.host.clone(),
             pool: None,
-        }
-    }
-}
+        };
 
-#[async_trait]
-impl RedisComponent for Redis {
-    async fn stop(&mut self) {
+        let url = format!("redis://{}", redis.redis_host);
+        log::debug!("Redis URL: {}", url);
+
+        match Config::from_url(url).create_pool(Some(Runtime::Tokio1)) {
+            Ok(pool) => {
+                redis.pool = Some(pool);
+            }
+            Err(err) => {
+                log::debug!("Error on connecting to redis: {:?}", err);
+                panic!("Unable to connect to redis {:?}", err)
+            }
+        };
+
+        redis
+    }
+    pub async fn stop(&mut self) {
         self.pool.as_mut().unwrap().close()
     }
 
-    async fn run(&mut self) -> Result<(), RedisError> {
-        if self.pool.is_none() {
-            let url = format!("redis://{}", self.redis_host);
-            log::debug!("Redis URL: {}", url);
-
-            match Config::from_url(url).create_pool(Some(Runtime::Tokio1)) {
-                Ok(pool) => {
-                    self.pool = Some(pool);
-                }
-                Err(err) => {
-                    log::debug!("Error on connecting to redis: {:?}", err);
-                    panic!("Unable to connect to redis {:?}", err)
-                }
-            };
-
-            Ok(())
-        } else {
-            log::debug!("Redis Connection is already set.");
-            Ok(())
-        }
-    }
-
-    async fn get_async_connection(&mut self) -> Option<Connection> {
+    pub async fn get_async_connection(&mut self) -> Option<Connection> {
         match self.pool.as_mut().unwrap().get().await {
             Ok(connection) => Some(connection),
             Err(err) => {
@@ -76,6 +61,7 @@ impl RedisComponent for Redis {
     }
 }
 
+#[cfg_attr(test, faux::methods)]
 #[async_trait]
 impl Healthy for Redis {
     async fn is_healthy(&self) -> bool {

--- a/src/components/redis.rs
+++ b/src/components/redis.rs
@@ -39,7 +39,7 @@ impl Redis {
                 redis.pool = Some(pool);
             }
             Err(err) => {
-                log::debug!("Error on connecting to redis: {:?}", err);
+                log::error!("Error on connecting to redis: {:?}", err);
                 panic!("Unable to connect to redis {:?}", err)
             }
         };

--- a/src/components/synapse.rs
+++ b/src/components/synapse.rs
@@ -39,26 +39,3 @@ impl SynapseComponent {
         result
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use faux::when;
-
-    use super::*;
-
-    #[actix_web::test]
-    async fn should_get_an_empty_response() {
-        let mut synapse_mock = SynapseComponent::faux();
-
-        when!(synapse_mock.get_version).then(|_| {
-            Ok(VersionResponse {
-                versions: vec!["holaa".to_string()],
-                unstable_features: HashMap::new(),
-            })
-        });
-
-        let response = synapse_mock.get_version().await.unwrap();
-
-        assert_eq!(response.versions[0], "holaa")
-    }
-}

--- a/src/components/synapse.rs
+++ b/src/components/synapse.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
+#[cfg_attr(test, faux::create)]
 #[derive(Debug)]
 pub struct SynapseComponent {
     synapse_url: String,
@@ -11,10 +12,11 @@ pub const VERSION_URI: &str = "/_matrix/client/versions";
 
 #[derive(Deserialize, Serialize)]
 pub struct VersionResponse {
-    versions: Vec<String>,
-    unstable_features: HashMap<String, bool>,
+    pub versions: Vec<String>,
+    pub unstable_features: HashMap<String, bool>,
 }
 
+#[cfg_attr(test, faux::methods)]
 impl SynapseComponent {
     pub fn new(url: String) -> Self {
         if url.is_empty() {
@@ -35,5 +37,28 @@ impl SynapseComponent {
         };
 
         result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use faux::when;
+
+    use super::*;
+
+    #[actix_web::test]
+    async fn should_get_an_empty_response() {
+        let mut synapse_mock = SynapseComponent::faux();
+
+        when!(synapse_mock.get_version).then(|_| {
+            Ok(VersionResponse {
+                versions: vec!["holaa".to_string()],
+                unstable_features: HashMap::new(),
+            })
+        });
+
+        let response = synapse_mock.get_version().await.unwrap();
+
+        assert_eq!(response.versions[0], "holaa")
     }
 }

--- a/src/components/users_cache.rs
+++ b/src/components/users_cache.rs
@@ -6,12 +6,14 @@ use super::redis::Redis;
 
 const DEFAULT_EXPIRATION_TIME_SECONDS: i32 = 120;
 
+#[cfg_attr(test, faux::create)]
 #[derive(Debug)]
 pub struct UsersCacheComponent {
     redis_component: Redis,
     hashing_key: String,
 }
 
+#[cfg_attr(test, faux::methods)]
 impl UsersCacheComponent {
     pub fn new(redis: Redis, hashing_key: String) -> Self {
         Self {

--- a/src/components/users_cache.rs
+++ b/src/components/users_cache.rs
@@ -1,21 +1,19 @@
-use std::error::Error;
-
-use deadpool_redis::redis::{cmd, RedisError, RedisResult};
+use deadpool_redis::redis::{cmd, RedisResult};
 
 use crate::utils::encrypt_string::hash_with_key;
 
-use super::redis::RedisComponent;
+use super::redis::Redis;
 
 const DEFAULT_EXPIRATION_TIME_SECONDS: i32 = 120;
 
 #[derive(Debug)]
-pub struct UsersCacheComponent<T: RedisComponent> {
-    redis_component: T,
+pub struct UsersCacheComponent {
+    redis_component: Redis,
     hashing_key: String,
 }
 
-impl<T: RedisComponent + std::fmt::Debug> UsersCacheComponent<T> {
-    pub fn new(redis: T, hashing_key: String) -> Self {
+impl UsersCacheComponent {
+    pub fn new(redis: Redis, hashing_key: String) -> Self {
         Self {
             redis_component: redis,
             hashing_key,
@@ -94,38 +92,21 @@ impl<T: RedisComponent + std::fmt::Debug> UsersCacheComponent<T> {
 
 #[cfg(test)]
 mod tests {
-    use async_trait::async_trait;
-    use deadpool_redis::{redis::RedisError, Connection};
 
-    use mockall::mock;
-
-    mock! {
-        #[derive(Debug)]
-        Redis {}
-
-        #[async_trait]
-        impl RedisComponent for Redis {
-            async fn stop(&mut self) {}
-            async fn run(&mut self) -> Result<(), RedisError> {}
-            async fn get_async_connection(&mut self) -> Option<Connection> {
-                None
-            }
-        }
-
-    }
+    use crate::components::redis::Redis;
 
     use super::*;
 
     #[actix_web::test]
     async fn test_should_return_no_connection_available() -> Result<(), String> {
-        let mut redis = MockRedis::new();
+        let mut redis_mock = Redis::faux();
 
         let token = "my test token";
         let user_id = "joni";
 
-        redis.expect_get_async_connection().return_once(|| None);
+        faux::when!(redis_mock.get_async_connection).then(|_| None);
 
-        let mut user_cache_component = UsersCacheComponent::new(redis, "test_key".to_string());
+        let mut user_cache_component = UsersCacheComponent::new(redis_mock, "test_key".to_string());
 
         let res = user_cache_component.add_user(token, user_id, None).await;
 

--- a/tests/components/redis.rs
+++ b/tests/components/redis.rs
@@ -1,23 +1,12 @@
 #[cfg(test)]
 mod tests {
     use deadpool_redis::redis::cmd;
-    use social_service::components::{
-        configuration::Redis as RedisConfig,
-        redis::{Redis, RedisComponent},
-    };
+    use social_service::components::{configuration::Redis as RedisConfig, redis::Redis};
 
     async fn create_redis_component() -> Redis {
-        let mut redis = Redis::new(&RedisConfig {
+        let redis = Redis::new_and_run(&RedisConfig {
             host: "0.0.0.0:6379".to_string(),
         });
-
-        match redis.run().await {
-            Err(err) => {
-                log::debug!("Error while connecting to redis: {:?}", err);
-                panic!("Unable connecting to redis {:?}", err)
-            }
-            _ => {}
-        }
 
         redis
     }

--- a/tests/components/users_cache.rs
+++ b/tests/components/users_cache.rs
@@ -4,27 +4,17 @@ mod tests {
     use std::time::Duration;
 
     use social_service::components::{
-        configuration::Redis as RedisConfig,
-        redis::{Redis, RedisComponent},
-        users_cache::UsersCacheComponent,
+        configuration::Redis as RedisConfig, redis::Redis, users_cache::UsersCacheComponent,
     };
 
     use actix_rt::time::sleep;
 
     const TEST_KEY: &str = "TEST KEY";
 
-    async fn create_users_cache_component() -> UsersCacheComponent<Redis> {
-        let mut redis = Redis::new(&RedisConfig {
+    async fn create_users_cache_component() -> UsersCacheComponent {
+        let redis = Redis::new_and_run(&RedisConfig {
             host: "0.0.0.0:6379".to_string(),
         });
-
-        match redis.run().await {
-            Err(err) => {
-                log::debug!("Error while connecting to redis: {:?}", err);
-                panic!("Unable connecting to redis {:?}", err)
-            }
-            _ => {}
-        }
 
         UsersCacheComponent::new(redis, TEST_KEY.to_string())
     }


### PR DESCRIPTION
This PR:
- replace `mockall` for `faux` crate

It's a variant of PR #76 and closes #74 