### PR TITLE
feat: sniff synapse login

### DIFF
--- a/src/components/app.rs
+++ b/src/components/app.rs
@@ -1,3 +1,5 @@
+use futures_util::lock::Mutex;
+
 use super::configuration::Database;
 use super::{
     configuration::Config, database::DatabaseComponent, health::HealthComponent,
@@ -8,8 +10,6 @@ use super::{
     redis::Redis,
     users_cache::{self, UsersCacheComponent},
 };
-
-use std::sync::Mutex;
 
 pub struct AppComponents {
     pub health: HealthComponent,

--- a/src/components/app.rs
+++ b/src/components/app.rs
@@ -26,6 +26,33 @@ pub struct CustomComponents {
     pub redis: Option<Redis>,
 }
 
+impl CustomComponents {
+    pub fn builder() -> Self {
+        Self {
+            synapse: None,
+            db: None,
+            users_cache: None,
+            redis: None,
+        }
+    }
+
+    pub fn with_synapse(&mut self, synapse: SynapseComponent) {
+        self.synapse = Some(synapse);
+    }
+
+    pub fn with_db(&mut self, db: DatabaseComponent) {
+        self.db = Some(db);
+    }
+
+    pub fn with_users_cache(&mut self, users_cache: UsersCacheComponent) {
+        self.users_cache = Some(users_cache);
+    }
+
+    pub fn with_redis(&mut self, redis: Redis) {
+        self.redis = Some(redis);
+    }
+}
+
 impl AppComponents {
     pub async fn new(
         custom_config: Option<Config>,

--- a/src/components/app.rs
+++ b/src/components/app.rs
@@ -26,30 +26,48 @@ pub struct CustomComponents {
     pub redis: Option<Redis>,
 }
 
-impl CustomComponents {
-    pub fn builder() -> Self {
-        Self {
-            synapse: None,
-            db: None,
-            users_cache: None,
-            redis: None,
+#[derive(Default)]
+pub struct CustomComponentsBuilder {
+    synapse: Option<SynapseComponent>,
+    db: Option<DatabaseComponent>,
+    users_cache: Option<UsersCacheComponent>,
+    redis: Option<Redis>,
+}
+
+impl CustomComponentsBuilder {
+    pub fn with_synapse(mut self, synapse: SynapseComponent) -> Self {
+        self.synapse = Some(synapse);
+        self
+    }
+
+    pub fn with_db(mut self, db: DatabaseComponent) -> Self {
+        self.db = Some(db);
+        self
+    }
+
+    pub fn with_users_cache(mut self, users_cache: UsersCacheComponent) -> Self {
+        self.users_cache = Some(users_cache);
+        self
+    }
+
+    pub fn with_redis(mut self, redis: Redis) -> Self {
+        self.redis = Some(redis);
+        self
+    }
+
+    pub fn build(self) -> CustomComponents {
+        CustomComponents {
+            synapse: self.synapse,
+            db: self.db,
+            users_cache: self.users_cache,
+            redis: self.redis,
         }
     }
+}
 
-    pub fn with_synapse(&mut self, synapse: SynapseComponent) {
-        self.synapse = Some(synapse);
-    }
-
-    pub fn with_db(&mut self, db: DatabaseComponent) {
-        self.db = Some(db);
-    }
-
-    pub fn with_users_cache(&mut self, users_cache: UsersCacheComponent) {
-        self.users_cache = Some(users_cache);
-    }
-
-    pub fn with_redis(&mut self, redis: Redis) {
-        self.redis = Some(redis);
+impl CustomComponents {
+    pub fn builder() -> CustomComponentsBuilder {
+        CustomComponentsBuilder::default()
     }
 }
 

--- a/src/components/synapse.rs
+++ b/src/components/synapse.rs
@@ -31,14 +31,14 @@ pub struct SynapseErrorResponse {
     pub error: String,
     pub soft_logout: bool,
 }
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct LoginIdentifier {
     #[serde(rename = "type")]
     pub _type: String,
     pub user: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct AuthChain {
     #[serde(rename = "type")]
     pub _type: String,
@@ -46,7 +46,7 @@ pub struct AuthChain {
     pub signature: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct SynapseLoginRequest {
     #[serde(rename = "type")]
     pub _type: String,
@@ -96,6 +96,7 @@ impl SynapseComponent {
         }
     }
 
+    #[tracing::instrument(name = "who_am_i function > Synapse components")]
     pub async fn who_am_i(&self, token: &str) -> Result<WhoAmIResponse, CommonError> {
         let who_am_i_url = format!("{}{}", self.synapse_url, WHO_AM_I_URI);
         let client = reqwest::Client::new();
@@ -142,6 +143,7 @@ impl SynapseComponent {
         }
     }
 
+    #[tracing::instrument(name = "login function > Synapse components")]
     pub async fn login(
         &self,
         request: SynapseLoginRequest,

--- a/src/components/synapse.rs
+++ b/src/components/synapse.rs
@@ -165,10 +165,7 @@ impl SynapseComponent {
 
                 let login_response = serde_json::from_str::<SynapseLoginResponse>(&text);
 
-                match login_response {
-                    Ok(res) => Ok(res),
-                    Err(_) => Err(SynapseComponent::parse_and_return_error(&text)),
-                }
+                login_response.map_err(|_| SynapseComponent::parse_and_return_error(&text))
             }
             Err(err) => {
                 log::warn!("error connecting to synapse {}", err);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ use middlewares::metrics_token::CheckMetricsToken;
 use routes::v1::friendships::get::get_user_friends;
 use routes::{
     health::handlers::{health, live},
-    synapse::handlers::version,
+    synapse::handlers::{login, version},
 };
 
 #[derive(Clone)]
@@ -75,6 +75,7 @@ pub fn get_app_router(
         .service(health)
         .service(version)
         .service(get_user_friends)
+        .service(login)
 }
 
 fn generate_uuid_v4() -> String {

--- a/src/middlewares/check_auth.rs
+++ b/src/middlewares/check_auth.rs
@@ -228,14 +228,13 @@ mod tests {
         when!(mocked_users_cache.add_user).times(0);
         when!(mocked_synapse.who_am_i).times(0);
 
-        let mocked_components = CustomComponents {
-            synapse: Some(mocked_synapse),
-            db: Some(mocked_db),
-            users_cache: Some(mocked_users_cache),
-            redis: Some(mocked_redis),
-        };
+        let mut mocked_comps = CustomComponents::builder();
+        mocked_comps.with_synapse(mocked_synapse);
+        mocked_comps.with_db(mocked_db);
+        mocked_comps.with_redis(mocked_redis);
+        mocked_comps.with_users_cache(mocked_users_cache);
 
-        let app_data = Data::new(AppComponents::new(Some(cfg), Some(mocked_components)).await);
+        let app_data = Data::new(AppComponents::new(Some(cfg), Some(mocked_comps)).await);
         let opts = vec!["/need-auth".to_string()];
         // unit app to unit test middleware
         let app = actix_web::test::init_service(
@@ -282,14 +281,13 @@ mod tests {
         });
         when!(mocked_synapse.who_am_i).once();
 
-        let mocked_components = CustomComponents {
-            synapse: Some(mocked_synapse),
-            db: Some(mocked_db),
-            users_cache: Some(mocked_users_cache),
-            redis: Some(mocked_redis),
-        };
+        let mut mocked_comps = CustomComponents::builder();
+        mocked_comps.with_synapse(mocked_synapse);
+        mocked_comps.with_db(mocked_db);
+        mocked_comps.with_redis(mocked_redis);
+        mocked_comps.with_users_cache(mocked_users_cache);
 
-        let app_data = Data::new(AppComponents::new(Some(cfg), Some(mocked_components)).await);
+        let app_data = Data::new(AppComponents::new(Some(cfg), Some(mocked_comps)).await);
         let opts = vec!["/need-auth".to_string()];
         // unit app to unit test middleware
         let app = actix_web::test::init_service(

--- a/src/middlewares/check_auth.rs
+++ b/src/middlewares/check_auth.rs
@@ -119,7 +119,7 @@ where
 
         Box::pin(async move {
             let user_id = {
-                let mut user_cache = components.users_cache.lock().unwrap();
+                let mut user_cache = components.users_cache.lock().await;
                 match user_cache.get_user(&token).await {
                     Ok(user_id) => Ok(user_id),
                     Err(_) => match components.synapse.who_am_i(&token).await {

--- a/src/middlewares/check_auth.rs
+++ b/src/middlewares/check_auth.rs
@@ -228,11 +228,12 @@ mod tests {
         when!(mocked_users_cache.add_user).times(0);
         when!(mocked_synapse.who_am_i).times(0);
 
-        let mut mocked_comps = CustomComponents::builder();
-        mocked_comps.with_synapse(mocked_synapse);
-        mocked_comps.with_db(mocked_db);
-        mocked_comps.with_redis(mocked_redis);
-        mocked_comps.with_users_cache(mocked_users_cache);
+        let mocked_comps = CustomComponents::builder()
+            .with_db(mocked_db)
+            .with_redis(mocked_redis)
+            .with_synapse(mocked_synapse)
+            .with_users_cache(mocked_users_cache)
+            .build();
 
         let app_data = Data::new(AppComponents::new(Some(cfg), Some(mocked_comps)).await);
         let opts = vec!["/need-auth".to_string()];
@@ -281,11 +282,12 @@ mod tests {
         });
         when!(mocked_synapse.who_am_i).once();
 
-        let mut mocked_comps = CustomComponents::builder();
-        mocked_comps.with_synapse(mocked_synapse);
-        mocked_comps.with_db(mocked_db);
-        mocked_comps.with_redis(mocked_redis);
-        mocked_comps.with_users_cache(mocked_users_cache);
+        let mocked_comps = CustomComponents::builder()
+            .with_db(mocked_db)
+            .with_redis(mocked_redis)
+            .with_synapse(mocked_synapse)
+            .with_users_cache(mocked_users_cache)
+            .build();
 
         let app_data = Data::new(AppComponents::new(Some(cfg), Some(mocked_comps)).await);
         let opts = vec!["/need-auth".to_string()];

--- a/src/routes/synapse/handlers.rs
+++ b/src/routes/synapse/handlers.rs
@@ -1,9 +1,12 @@
-use crate::components::{app::AppComponents, synapse::SynapseLoginRequest};
+use crate::{
+    components::{app::AppComponents, synapse::SynapseLoginRequest},
+    routes::v1::error::CommonError,
+};
 
 use actix_web::{
     get, post,
     web::{self, Data},
-    HttpResponse,
+    HttpResponse, ResponseError,
 };
 
 #[get("/_matrix/client/versions")]
@@ -31,9 +34,12 @@ pub async fn login(
             {
                 HttpResponse::Ok().json(ok_response)
             } else {
-                HttpResponse::InternalServerError().finish()
+                log::error!(
+                    "login handler: Error on storing hashed token and user id into users redis cache"
+                );
+                CommonError::Unknown.error_response()
             }
         }
-        Err(err_response) => HttpResponse::InternalServerError().json(err_response),
+        Err(err_response) => err_response.error_response(),
     }
 }

--- a/src/routes/synapse/handlers.rs
+++ b/src/routes/synapse/handlers.rs
@@ -1,6 +1,10 @@
-use crate::components::app::AppComponents;
+use crate::components::{app::AppComponents, synapse::SynapseLoginRequest};
 
-use actix_web::{get, web::Data, HttpResponse};
+use actix_web::{
+    get, post,
+    web::{self, Data},
+    HttpResponse,
+};
 
 #[get("/_matrix/client/versions")]
 pub async fn version(app_data: Data<AppComponents>) -> HttpResponse {
@@ -9,5 +13,27 @@ pub async fn version(app_data: Data<AppComponents>) -> HttpResponse {
     match version_response {
         Ok(ok_response) => HttpResponse::Ok().json(ok_response),
         Err(err_response) => HttpResponse::from_error(err_response),
+    }
+}
+
+#[post("/_matrix/client/r0/login")]
+pub async fn login(
+    app_data: Data<AppComponents>,
+    payload: web::Json<SynapseLoginRequest>,
+) -> HttpResponse {
+    match app_data.synapse.login(payload.0).await {
+        Ok(ok_response) => {
+            let mut users_cache = app_data.users_cache.lock().await;
+            if users_cache
+                .add_user(&ok_response.access_token, &ok_response.user_id, None)
+                .await
+                .is_ok()
+            {
+                HttpResponse::Ok().json(ok_response)
+            } else {
+                HttpResponse::InternalServerError().finish()
+            }
+        }
+        Err(err_response) => HttpResponse::InternalServerError().json(err_response),
     }
 }

--- a/tests/routes/mod.rs
+++ b/tests/routes/mod.rs
@@ -1,2 +1,3 @@
 pub mod health;
 pub mod metrics;
+pub mod synapse;

--- a/tests/routes/synapse.rs
+++ b/tests/routes/synapse.rs
@@ -16,6 +16,7 @@ mod synapse_sniff {
                 },
             },
             get_app_router,
+            routes::v1::error::CommonError,
         };
 
         const URL: &str = "/_matrix/client/r0/login";
@@ -100,6 +101,71 @@ mod synapse_sniff {
             let user = user.unwrap();
             assert_eq!(user, "0xA1");
             assert!(response.status().is_success())
+        }
+
+        #[actix_web::test]
+        async fn should_be_500_and_not_user_in_cache() {
+            let config = get_configuration();
+
+            // Just mocks synapse
+            let mut mocked_synapse = SynapseComponent::faux();
+
+            when!(mocked_synapse.login).then(|_| Err(CommonError::Unknown));
+
+            let mocked_comps = CustomComponents {
+                synapse: Some(mocked_synapse),
+                db: None,
+                users_cache: None,
+                redis: None,
+            };
+
+            // Manual Setup
+            create_test_db(&config.db).await;
+            let app_components = AppComponents::new(Some(config), Some(mocked_comps)).await;
+            let app_data = Data::new(app_components);
+
+            let router = get_app_router(&app_data);
+
+            let app = test::init_service(router).await;
+
+            let login_req = SynapseLoginRequest {
+                _type: "m.login.decentraland".to_string(),
+                identifier: LoginIdentifier {
+                    _type: "m.id.user".to_string(),
+                    user: "0xB1".to_string(),
+                },
+                timestamp: "1671211160629".to_string(),
+                auth_chain: vec![
+                    AuthChain {
+                        _type: "SIGNER".to_string(),
+                        payload: "0xB1".to_string(),
+                        signature: "".to_string(),
+                    },
+                    AuthChain {
+                        _type: "ECDSA_EPHEMERAL".to_string(),
+                        payload: "stuff".to_string(),
+                        signature: "stuff".to_string(),
+                    },
+                    AuthChain {
+                        _type: "ECDSA_SIGNED_ENTITY".to_string(),
+                        payload: "stuff".to_string(),
+                        signature: "stuff".to_string(),
+                    },
+                ],
+            };
+
+            let req = test::TestRequest::post()
+                .uri(URL)
+                .set_json(login_req)
+                .to_request();
+
+            let response = test::call_service(&app, req).await;
+
+            // Test if all happenned correctly
+            let mut users_cache = app_data.users_cache.lock().await;
+            let user = users_cache.get_user("0xB1_TOKEN").await;
+            assert!(user.is_err());
+            assert!(response.status().is_server_error())
         }
     }
 }

--- a/tests/routes/synapse.rs
+++ b/tests/routes/synapse.rs
@@ -1,0 +1,105 @@
+#[cfg(test)]
+mod synapse_sniff {
+
+    mod login {
+        use std::collections::HashMap;
+
+        use crate::helpers::server::{create_test_db, get_configuration};
+        use actix_web::{test, web::Data};
+        use faux::when;
+        use social_service::{
+            components::{
+                app::{AppComponents, CustomComponents},
+                synapse::{
+                    AuthChain, LoginIdentifier, SynapseComponent, SynapseLoginRequest,
+                    SynapseLoginResponse,
+                },
+            },
+            get_app_router,
+        };
+
+        const URL: &str = "/_matrix/client/r0/login";
+
+        #[actix_web::test]
+        async fn should_be_200_and_has_user_in_cache() {
+            let config = get_configuration();
+
+            // Just mocks synapse
+            let mut mocked_synapse = SynapseComponent::faux();
+
+            when!(mocked_synapse.login).then(|_| {
+                let mut mocked_hash_map = HashMap::new();
+                let mut mocked_hash_map_2 = HashMap::new();
+                mocked_hash_map_2.insert(
+                    "base_url".to_string(),
+                    "https://synapse.decentraland.zone".to_string(),
+                );
+                mocked_hash_map.insert("m.homeserver".to_string(), mocked_hash_map_2);
+                Ok(SynapseLoginResponse {
+                    user_id: "0xA1".to_string(),
+                    access_token: "0xA1_TOKEN".to_string(),
+                    device_id: "0xA1_DEVICE".to_string(),
+                    home_server: "decentraland.zone".to_string(),
+                    well_known: mocked_hash_map,
+                })
+            });
+
+            let mocked_comps = CustomComponents {
+                synapse: Some(mocked_synapse),
+                db: None,
+                users_cache: None,
+                redis: None,
+            };
+
+            // Manual Setup
+            create_test_db(&config.db).await;
+            let app_components = AppComponents::new(Some(config), Some(mocked_comps)).await;
+            let app_data = Data::new(app_components);
+
+            let router = get_app_router(&app_data);
+
+            let app = test::init_service(router).await;
+
+            let login_req = SynapseLoginRequest {
+                _type: "m.login.decentraland".to_string(),
+                identifier: LoginIdentifier {
+                    _type: "m.id.user".to_string(),
+                    user: "0xA1".to_string(),
+                },
+                timestamp: "1671211160629".to_string(),
+                auth_chain: vec![
+                    AuthChain {
+                        _type: "SIGNER".to_string(),
+                        payload: "0xA1".to_string(),
+                        signature: "".to_string(),
+                    },
+                    AuthChain {
+                        _type: "ECDSA_EPHEMERAL".to_string(),
+                        payload: "stuff".to_string(),
+                        signature: "stuff".to_string(),
+                    },
+                    AuthChain {
+                        _type: "ECDSA_SIGNED_ENTITY".to_string(),
+                        payload: "stuff".to_string(),
+                        signature: "stuff".to_string(),
+                    },
+                ],
+            };
+
+            let req = test::TestRequest::post()
+                .uri(URL)
+                .set_json(login_req)
+                .to_request();
+
+            let response = test::call_service(&app, req).await;
+
+            // Test if all happenned correctly
+            let mut users_cache = app_data.users_cache.lock().await;
+            let user = users_cache.get_user("0xA1_TOKEN").await;
+            assert!(user.is_ok());
+            let user = user.unwrap();
+            assert_eq!(user, "0xA1");
+            assert!(response.status().is_success())
+        }
+    }
+}

--- a/tests/routes/synapse.rs
+++ b/tests/routes/synapse.rs
@@ -45,8 +45,9 @@ mod synapse_sniff {
                 })
             });
 
-            let mut mocked_comps = CustomComponents::builder();
-            mocked_comps.with_synapse(mocked_synapse);
+            let mocked_comps = CustomComponents::builder()
+                .with_synapse(mocked_synapse)
+                .build();
 
             // Manual Setup
             create_test_db(&config.db).await;
@@ -108,8 +109,9 @@ mod synapse_sniff {
 
             when!(mocked_synapse.login).then(|_| Err(CommonError::Unknown));
 
-            let mut mocked_comps = CustomComponents::builder();
-            mocked_comps.with_synapse(mocked_synapse);
+            let mocked_comps = CustomComponents::builder()
+                .with_synapse(mocked_synapse)
+                .build();
 
             // Manual Setup
             create_test_db(&config.db).await;

--- a/tests/routes/synapse.rs
+++ b/tests/routes/synapse.rs
@@ -45,12 +45,8 @@ mod synapse_sniff {
                 })
             });
 
-            let mocked_comps = CustomComponents {
-                synapse: Some(mocked_synapse),
-                db: None,
-                users_cache: None,
-                redis: None,
-            };
+            let mut mocked_comps = CustomComponents::builder();
+            mocked_comps.with_synapse(mocked_synapse);
 
             // Manual Setup
             create_test_db(&config.db).await;
@@ -112,12 +108,8 @@ mod synapse_sniff {
 
             when!(mocked_synapse.login).then(|_| Err(CommonError::Unknown));
 
-            let mocked_comps = CustomComponents {
-                synapse: Some(mocked_synapse),
-                db: None,
-                users_cache: None,
-                redis: None,
-            };
+            let mut mocked_comps = CustomComponents::builder();
+            mocked_comps.with_synapse(mocked_synapse);
 
             // Manual Setup
             create_test_db(&config.db).await;


### PR DESCRIPTION
This PR:
- fix Mutex not async-aware
- add `/login` route to sniff synapse logins
- store hashed user access token in Redis cache after `POST /login` (synapse)