### PR TITLE
fix: order addresses in friendships

### DIFF
--- a/src/entities/friendships.rs
+++ b/src/entities/friendships.rs
@@ -297,8 +297,8 @@ fn order_addresses<'a>(addresses: (&'a str, &'a str)) -> (&'a str, &'a str) {
     let (address1, address2) = addresses;
 
     if address1 < address2 {
-        return addresses;
+        addresses
     } else {
-        return (address2, address1);
+        (address2, address1)
     }
 }

--- a/src/entities/friendships.rs
+++ b/src/entities/friendships.rs
@@ -101,6 +101,7 @@ impl FriendshipRepositoryImplementation for FriendshipsRepository {
         is_active: bool,
         transaction: Option<Transaction<'a, Postgres>>,
     ) -> (Result<Uuid, sqlx::Error>, Option<Transaction<'a, Postgres>>) {
+        // The addresses are order lexicographic to ensure that the friendship tuple is unique
         let (address1, address2) = order_addresses(addresses);
 
         let id = Uuid::parse_str(generate_uuid_v4().as_str()).unwrap();

--- a/src/entities/friendships.rs
+++ b/src/entities/friendships.rs
@@ -101,7 +101,7 @@ impl FriendshipRepositoryImplementation for FriendshipsRepository {
         is_active: bool,
         transaction: Option<Transaction<'a, Postgres>>,
     ) -> (Result<Uuid, sqlx::Error>, Option<Transaction<'a, Postgres>>) {
-        let (address1, address2) = addresses;
+        let (address1, address2) = order_addresses(addresses);
 
         let id = Uuid::parse_str(generate_uuid_v4().as_str()).unwrap();
 
@@ -290,5 +290,15 @@ impl FriendshipRepositoryImplementation for FriendshipsRepository {
             Some(transaction) => Executor::Transaction(transaction),
             None => Executor::Pool(DatabaseComponent::get_connection(&self.db_connection)),
         }
+    }
+}
+
+fn order_addresses<'a>(addresses: (&'a str, &'a str)) -> (&'a str, &'a str) {
+    let (address1, address2) = addresses;
+
+    if address1 < address2 {
+        return addresses;
+    } else {
+        return (address2, address1);
     }
 }

--- a/tests/component_database.rs
+++ b/tests/component_database.rs
@@ -13,7 +13,7 @@ async fn should_create_and_get_a_friendship() {
     let dbrepos = db.db_repos.as_ref().unwrap();
     dbrepos
         .friendships
-        .create_new_friendships(("A", "B"), false, None)
+        .create_new_friendships(("B", "A"), false, None)
         .await
         .0
         .unwrap();


### PR DESCRIPTION
Store friendships in lexicographic order in the database, this way always `address_1 <= address_2`