### PR TITLE
fix: get friendships query

### DIFF
--- a/src/entities/friendships.rs
+++ b/src/entities/friendships.rs
@@ -183,7 +183,7 @@ impl FriendshipRepositoryImplementation for FriendshipsRepository {
         let active_only_clause = " AND is_active";
 
         let mut query =
-            "SELECT * FROM friendships WHERE ((LOWER(address_1) = $1) OR (LOWER(address_2) = $1))".to_owned();
+            "SELECT * FROM friendships WHERE (LOWER(address_1) = $1 OR LOWER(address_2) = $1)".to_owned();
 
         if only_active {
             query.push_str(active_only_clause);

--- a/src/entities/friendships.rs
+++ b/src/entities/friendships.rs
@@ -183,7 +183,7 @@ impl FriendshipRepositoryImplementation for FriendshipsRepository {
         let active_only_clause = " AND is_active";
 
         let mut query =
-            "SELECT * FROM friendships WHERE (LOWER(address_1) = $1) OR (LOWER(address_2) = $1)".to_owned();
+            "SELECT * FROM friendships WHERE ((LOWER(address_1) = $1) OR (LOWER(address_2) = $1))".to_owned();
 
         if only_active {
             query.push_str(active_only_clause);


### PR DESCRIPTION
Missing braces made GET /friendships return also inactive