### PR TITLE
refactor: improve use of lifetimes

### DIFF
--- a/src/components/database.rs
+++ b/src/components/database.rs
@@ -72,10 +72,10 @@ impl DatabaseComponent {
         db_connection.as_ref().as_ref().unwrap()
     }
 
-    pub async fn execute_query(
+    pub async fn execute_query<'a>(
         query: Query<'_, Postgres, PgArguments>,
-        executor: Executor<'static>,
-    ) -> (Result<PgQueryResult, Error>, Option<Executor<'static>>) {
+        executor: Executor<'a>,
+    ) -> (Result<PgQueryResult, Error>, Option<Executor<'a>>) {
         match executor {
             Executor::Transaction(mut transaction) => (
                 query.execute(&mut transaction).await,

--- a/src/entities/friendship_history.rs
+++ b/src/entities/friendship_history.rs
@@ -139,7 +139,7 @@ impl FriendshipHistoryRepository {
         transaction: Option<Transaction<'static, Postgres>>,
     ) -> Executor<'static> {
         transaction.map_or_else(
-            || Executor::Pool(DatabaseComponent::get_connection(&self.db_connection).clone()), // Clone because it's cheap and the pool use an Arc internally
+            || Executor::Pool(DatabaseComponent::get_connection(&self.db_connection).clone()), // choose to Clone because it's cheap and the pool use an Arc internally
             Executor::Transaction,
         )
     }

--- a/src/entities/friendships.rs
+++ b/src/entities/friendships.rs
@@ -309,7 +309,7 @@ impl FriendshipRepositoryImplementation for FriendshipsRepository {
         match transaction {
             Some(transaction) => Executor::Transaction(transaction),
             None => {
-                // Clone because it's cheap and the pool use an Arc internally
+                // choose to Clone because it's cheap and the pool use an Arc internally
                 let conn = DatabaseComponent::get_connection(&self.db_connection).clone();
                 Executor::Pool(conn)
             }

--- a/src/entities/user_features.rs
+++ b/src/entities/user_features.rs
@@ -26,9 +26,9 @@ impl UserFeaturesRepository {
 
     pub async fn create(
         &self,
-        user: String,
-        feature_name: String,
-        feature_value: String,
+        user: &str,
+        feature_name: &str,
+        feature_value: &str,
     ) -> Result<(), sqlx::Error> {
         let db_conn = DatabaseComponent::get_connection(&self.db_connection);
 
@@ -46,11 +46,11 @@ impl UserFeaturesRepository {
 
     pub async fn get_all_user_features(
         &self,
-        user: String,
+        user: &str,
     ) -> Result<Option<UserFeatures>, sqlx::Error> {
         let db_conn = DatabaseComponent::get_connection(&self.db_connection);
         match sqlx::query("SELECT * FROM user_features WHERE \"user\" = $1")
-            .bind(user.as_str())
+            .bind(user)
             .fetch_all(db_conn)
             .await
         {
@@ -59,7 +59,7 @@ impl UserFeaturesRepository {
                     Ok(None)
                 } else {
                     let mut all_user_features = UserFeatures {
-                        user,
+                        user: user.to_string(),
                         features: Vec::new(),
                     };
                     for result in row {

--- a/src/routes/synapse/room_events.rs
+++ b/src/routes/synapse/room_events.rs
@@ -199,9 +199,8 @@ async fn process_room_event(
 
     // Start transaction
     let transaction = friendship_ports.db.start_transaction().await;
-    if transaction.is_err() {
-        let err = transaction.err().unwrap();
-        log::error!("Couldn't start transaction to store friendship update {err}");
+    if let Err(error) = transaction {
+        log::error!("Couldn't start transaction to store friendship update {error}");
         return Err(SynapseError::CommonError(CommonError::Unknown));
     }
 

--- a/src/routes/synapse/room_events.rs
+++ b/src/routes/synapse/room_events.rs
@@ -196,13 +196,13 @@ async fn process_room_event<'a>(
     }
 
     // Start transaction
-    let transaction = friendship_ports.db.start_transaction().await;
-    if let Err(error) = transaction {
-        log::error!("Couldn't start transaction to store friendship update {error}");
-        return Err(SynapseError::CommonError(CommonError::Unknown));
-    }
-
-    let transaction = transaction.unwrap();
+    let transaction = match friendship_ports.db.start_transaction().await {
+        Ok(tx) => tx,
+        Err(error) => {
+            log::error!("Couldn't start transaction to store friendship update {error}");
+            return Err(SynapseError::CommonError(CommonError::Unknown));
+        }
+    };
 
     // UPDATE FRIENDSHIP ACCORDINGLY IN DB
     let transaction = update_friendship_status(

--- a/tests/component_database.rs
+++ b/tests/component_database.rs
@@ -85,16 +85,12 @@ async fn should_create_a_user_feature() {
     let dbrepos = db.db_repos.as_ref().unwrap();
     dbrepos
         .user_features
-        .create(
-            "A".to_string(),
-            "exposure_level".to_string(),
-            "anyone".to_string(),
-        )
+        .create("A", "exposure_level", "anyone")
         .await
         .unwrap();
     let user_features = dbrepos
         .user_features
-        .get_all_user_features("A".to_string())
+        .get_all_user_features("A")
         .await
         .unwrap();
     assert!(user_features.is_some());


### PR DESCRIPTION
This PR:
- refactors the use of the lifetimes for DB `Transaction` in order to make it more flexible and usable in any context. 

Related to what we talk with @Julieta11 on #140 