### PR TITLE
refactor: use SocialContext in RPC Server and not AppComponents

### DIFF
--- a/configuration.toml
+++ b/configuration.toml
@@ -1,7 +1,5 @@
 [server]
-host = "0.0.0.0"
 port = 5000
 
 [rpc_server]
-host = "0.0.0.0"
 port = 8085

--- a/configuration.toml
+++ b/configuration.toml
@@ -1,3 +1,7 @@
 [server]
 host = "0.0.0.0"
 port = 5000
+
+[rpc_server]
+host = "0.0.0.0"
+port = 8085

--- a/src/api/app.rs
+++ b/src/api/app.rs
@@ -25,12 +25,10 @@ pub struct AppOptions {
 
 pub fn run_service(data: Data<AppComponents>) -> Result<Server, std::io::Error> {
     init_telemetry();
-
-    let server_host = data.config.server.host.clone();
     let server_port = data.config.server.port;
 
     let server = HttpServer::new(move || get_app_router(&data))
-        .bind((server_host, server_port))?
+        .bind(("0.0.0.0", server_port))?
         .run();
 
     Ok(server)

--- a/src/components/app.rs
+++ b/src/components/app.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use futures_util::lock::Mutex;
+use tokio::sync::Mutex;
 
 use super::configuration::Database;
 use super::{
@@ -15,9 +15,9 @@ use super::{
 
 pub struct AppComponents {
     pub health: HealthComponent,
-    pub synapse: Arc<SynapseComponent>,
+    pub synapse: SynapseComponent,
     pub config: Config,
-    pub db: Arc<DatabaseComponent>,
+    pub db: DatabaseComponent,
     pub users_cache: Arc<Mutex<UsersCacheComponent>>,
 }
 
@@ -43,8 +43,8 @@ impl AppComponents {
 
         Self {
             health,
-            db: Arc::new(db),
-            synapse: Arc::new(synapse),
+            db,
+            synapse,
             users_cache: Arc::new(Mutex::new(users_cache)),
             config,
         }

--- a/src/components/app.rs
+++ b/src/components/app.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use futures_util::lock::Mutex;
 
 use super::configuration::Database;
@@ -13,10 +15,10 @@ use super::{
 
 pub struct AppComponents {
     pub health: HealthComponent,
-    pub synapse: SynapseComponent,
+    pub synapse: Arc<SynapseComponent>,
     pub config: Config,
-    pub db: DatabaseComponent,
-    pub users_cache: Mutex<UsersCacheComponent>,
+    pub db: Arc<DatabaseComponent>,
+    pub users_cache: Arc<Mutex<UsersCacheComponent>>,
 }
 
 impl AppComponents {
@@ -41,9 +43,9 @@ impl AppComponents {
 
         Self {
             health,
-            db,
-            synapse,
-            users_cache: Mutex::new(users_cache),
+            db: Arc::new(db),
+            synapse: Arc::new(synapse),
+            users_cache: Arc::new(Mutex::new(users_cache)),
             config,
         }
     }

--- a/src/components/configuration.rs
+++ b/src/components/configuration.rs
@@ -24,7 +24,6 @@ pub struct Args {
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct Server {
-    pub host: String,
     pub port: u16,
 }
 
@@ -95,9 +94,7 @@ impl Config {
                     .with_list_parse_key(ENV_VAR)
                     .try_parsing(true),
             )
-            .set_override_option("server.host", args.host)?
-            .set_override_option("server.port", args.port)?
-            .set_override_option("rpc_server.host", args.rpc_host)?
+            .set_override_option("server_port", args.port)?
             .set_override_option("rpc_server.port", args.rpc_port)?
             .set_default("synapse.url", "https://synapse.decentraland.zone")?
             .set_default("env", "dev")?

--- a/src/components/configuration.rs
+++ b/src/components/configuration.rs
@@ -41,6 +41,7 @@ pub struct Database {
 #[derive(Debug, Deserialize, Clone)]
 pub struct Config {
     pub server: Server,
+    pub rpc_server: Server,
     pub synapse: Synapse,
     pub db: Database,
     pub env: String, // prd / stg / dev / biz

--- a/src/components/synapse.rs
+++ b/src/components/synapse.rs
@@ -7,7 +7,7 @@ use crate::api::routes::{
     v1::error::CommonError,
 };
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SynapseComponent {
     synapse_url: String,
 }

--- a/src/components/synapse.rs
+++ b/src/components/synapse.rs
@@ -7,7 +7,7 @@ use crate::api::routes::{
     v1::error::CommonError,
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct SynapseComponent {
     synapse_url: String,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
-use std::io;
+use std::{io, sync::Arc};
 
 use social_service::{
     api::app::{get_app_data, run_service},
-    ws::app::{run_ws_transport, ConfigRpcServer},
+    ws::app::{run_ws_transport, ConfigRpcServer, SocialContext},
 };
 use tokio::join;
 
@@ -14,11 +14,11 @@ async fn main() -> io::Result<()> {
 
     // Run WebSocket transport
     let ctx = SocialContext {
-        synapse: Arc::new(app_data.clone().synapse),
-        db: Arc::new(app_data.clone().db),
-        users_cache: Arc::new(app_data.clone().users_cache),
+        synapse: Arc::clone(&app_data.synapse),
+        db: Arc::clone(&app_data.db),
+        users_cache: Arc::clone(&app_data.users_cache),
         config: ConfigRpcServer {
-            rpc_server: app_data.into_inner().config.rpc_server,
+            rpc_server: app_data.config.rpc_server.clone(),
         },
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,20 +8,21 @@ use tokio::join;
 
 #[actix_web::main]
 async fn main() -> io::Result<()> {
-    // Run HTTP Server
+    // Get AppComponents
     let app_data = get_app_data(None).await;
+    // Run HTTP Server
     let server = run_service(app_data.clone()).unwrap();
 
-    // Run WebSocket transport
+    // Create Context to run RPC WebSocket transport
     let ctx = SocialContext {
-        synapse: Arc::clone(&app_data.synapse),
-        db: Arc::clone(&app_data.db),
+        synapse: app_data.synapse.clone(),
+        db: app_data.db.clone(),
         users_cache: Arc::clone(&app_data.users_cache),
         config: ConfigRpcServer {
             rpc_server: app_data.config.rpc_server.clone(),
         },
     };
-
+    // Run RPC Websocket Transport
     let (rpc_server_handle, http_server_handle) = run_ws_transport(ctx).await;
 
     // Wait for all tasks to complete

--- a/src/middlewares/check_auth.rs
+++ b/src/middlewares/check_auth.rs
@@ -121,10 +121,9 @@ where
         let svc = self.service.clone();
         Box::pin(async move {
             let components = request.app_data::<Data<AppComponents>>().unwrap().clone();
-            let context = components.into_inner();
             let user_id = get_user_id_from_token(
-                Arc::clone(&context.synapse),
-                Arc::clone(&context.users_cache),
+                Arc::clone(&components.synapse),
+                Arc::clone(&components.users_cache),
                 &token,
             )
             .await;

--- a/src/middlewares/check_auth.rs
+++ b/src/middlewares/check_auth.rs
@@ -13,8 +13,7 @@ use actix_web::{
 use futures_util::future::LocalBoxFuture;
 
 use crate::{
-    api::routes::v1::error::CommonError,
-    components::{app::AppComponents, users_cache},
+    api::routes::v1::error::CommonError, components::app::AppComponents,
     ports::users_cache::get_user_id_from_token,
 };
 
@@ -124,8 +123,8 @@ where
             let components = request.app_data::<Data<AppComponents>>().unwrap().clone();
             let context = components.into_inner();
             let user_id = get_user_id_from_token(
-                Arc::new(context.synapse.clone()),
-                Arc::new(context.users_cache),
+                Arc::clone(&context.synapse),
+                Arc::clone(&context.users_cache),
                 &token,
             )
             .await;

--- a/src/middlewares/check_auth.rs
+++ b/src/middlewares/check_auth.rs
@@ -4,7 +4,6 @@ use std::{
     sync::Arc,
 };
 
-use actix_http::StatusCode;
 use actix_web::{
     body::EitherBody,
     dev::{self, Service, ServiceRequest, ServiceResponse, Transform},
@@ -148,9 +147,8 @@ where
                 }
                 None => {
                     let (request, _pl) = request.into_parts();
-                    let response = HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR)
-                        .finish()
-                        .map_into_right_body();
+                    let response =
+                        HttpResponse::from_error(CommonError::Unknown).map_into_right_body();
                     Ok(ServiceResponse::new(request, response))
                 }
             }

--- a/src/ports/users_cache.rs
+++ b/src/ports/users_cache.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use crate::components::{synapse::SynapseComponent, users_cache::UsersCacheComponent};
 use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
 
 use crate::api::routes::v1::error::CommonError;
 
@@ -12,8 +13,8 @@ pub struct UserId {
 }
 
 pub async fn get_user_id_from_token(
-    synapse: Arc<SynapseComponent>,
-    users_cache: Arc<futures_util::lock::Mutex<UsersCacheComponent>>,
+    synapse: SynapseComponent,
+    users_cache: Arc<Mutex<UsersCacheComponent>>,
     token: &String,
 ) -> Result<UserId, CommonError> {
     // drop mutex lock at the end of scope

--- a/src/ws/app.rs
+++ b/src/ws/app.rs
@@ -88,7 +88,7 @@ pub async fn run_ws_transport(
     let routes = warp::get().and(rpc_route.or(rest_routes));
 
     let addr = match host.parse::<Ipv4Addr>() {
-        Ok(v) => SocketAddr::new(IpAddr::V4(v), port),
+        Ok(ip) => SocketAddr::new(IpAddr::V4(ip), port),
         Err(err) => {
             log::debug!("Running websocket server with default values as an error was found with the configuration: {:?}", err);
             ([0, 0, 0, 0], 8085).into()

--- a/src/ws/app.rs
+++ b/src/ws/app.rs
@@ -32,7 +32,7 @@ use crate::{
 };
 
 pub struct ConfigRpcServer {
-    rpc_server: Server,
+    pub rpc_server: Server,
 }
 
 pub struct SocialContext {
@@ -45,6 +45,9 @@ pub struct SocialContext {
 pub async fn run_ws_transport(
     ctx: SocialContext,
 ) -> (tokio::task::JoinHandle<()>, tokio::task::JoinHandle<()>) {
+    let port = ctx.config.rpc_server.port.clone();
+    let host = ctx.config.rpc_server.host.clone();
+
     if env_logger::try_init().is_err() {
         log::debug!("Logger already init")
     }
@@ -84,8 +87,8 @@ pub async fn run_ws_transport(
         .map(|| "\"alive\"".to_string());
     let routes = warp::get().and(rpc_route.or(rest_routes));
 
-    let addr = match ctx.config.rpc_server.host.parse::<Ipv4Addr>() {
-        Ok(v) => SocketAddr::new(IpAddr::V4(v), ctx.config.rpc_server.port),
+    let addr = match host.parse::<Ipv4Addr>() {
+        Ok(v) => SocketAddr::new(IpAddr::V4(v), port),
         Err(err) => {
             log::debug!("Running websocket server with default values as an error was found with the configuration: {:?}", err);
             ([0, 0, 0, 0], 8085).into()

--- a/src/ws/app.rs
+++ b/src/ws/app.rs
@@ -45,7 +45,7 @@ pub struct SocialContext {
 pub async fn run_ws_transport(
     ctx: SocialContext,
 ) -> (tokio::task::JoinHandle<()>, tokio::task::JoinHandle<()>) {
-    let port = ctx.config.rpc_server.port.clone();
+    let port = ctx.config.rpc_server.port;
     let host = ctx.config.rpc_server.host.clone();
 
     if env_logger::try_init().is_err() {

--- a/src/ws/service/friendships_service.rs
+++ b/src/ws/service/friendships_service.rs
@@ -21,7 +21,10 @@ impl FriendshipsServiceServer<SocialContext> for MyFriendshipsService {
     ) -> ServerStreamResponse<Users> {
         // Get user id from the auth token
         let user_id = match request.synapse_token {
-            Some(token) => get_user_id_from_token(context.app_components.clone(), &token).await,
+            Some(token) => {
+                get_user_id_from_token(context.synapse.clone(), context.users_cache.clone(), &token)
+                    .await
+            }
             None => {
                 // TODO: Handle no auth token.
                 log::debug!("Get Friends > Get User ID from Token > `synapse_token` is None.");
@@ -33,7 +36,7 @@ impl FriendshipsServiceServer<SocialContext> for MyFriendshipsService {
         match user_id {
             Ok(user_id) => {
                 // Look for users friends
-                let mut friendship = match context.app_components.db.db_repos.clone() {
+                let mut friendship = match context.db.db_repos.clone() {
                     Some(repos) => {
                         let friendship = repos
                             .friendships


### PR DESCRIPTION
AppComponents are the components necessary to run the REST server, avoid using it in the RPC Module, so all shared components are now Arc