### PR TITLE
feat: remove inactive friendships without history

### DIFF
--- a/migrations/20230419161219_remove-inactive-friendships-without-history.down.sql
+++ b/migrations/20230419161219_remove-inactive-friendships-without-history.down.sql
@@ -1,0 +1,1 @@
+-- A deletion can not be un-done

--- a/migrations/20230419161219_remove-inactive-friendships-without-history.up.sql
+++ b/migrations/20230419161219_remove-inactive-friendships-without-history.up.sql
@@ -1,0 +1,11 @@
+DELETE FROM friendships WHERE id IN(
+  SELECT f.id 
+	FROM friendships f
+	LEFT JOIN friendship_history h
+		ON f.id = h.friendship_id
+	WHERE
+		h.friendship_id IS NULL AND
+		f.id IS NOT NULL AND
+		f.synapse_room_id IS NULL AND
+		f.is_active = false
+);


### PR DESCRIPTION
fixes: https://github.com/decentraland/dservices/issues/61

### Changes
All friendships that meet all the following criteria are deleted:
- They are inactive
- They do not have a `synapse_room_id`
- They do not have any associated `friendship_history`

### Context

This Pull Request contains updates regarding the migration of `synapse_room_id` in the friendships table. The version that runs the migration on the friendships table has been deployed in `.zone`. Upon completion of the migration, it was observed that there are 405,764 friendships with `synapse_room_id`, while 52,921 friendships have `synapse_room_id = NULL`. It was determined that the 50,000 friendships with `NULL synapse_room_id` are inactive and were stored as such during the migration from Synapse to the Social Service. This means that to obtain the room_id for these friendships it must be obtained from Synapse, as they can not be inferred from `friendship_history.metadata` as in other cases.

The solution proposed to that problem is implemented in this PR and described below:
Delete all inactive friendships from the Social Service database that do not have `friendship_history` nor `synapse_room_id`. Since these friendships have been rejected, they represent two individuals who were never friends, and there is no use case for storing them. Since the inactive friendships were stored only for informational purposes and no use case was found for keeping them, there is no loss of data in doing this migration.