### PR TITLE
fix: `build_room_alias_name` and `extract_domain`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2657,6 +2657,7 @@ dependencies = [
  "tracing-log",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "urlencoding",
  "uuid",
  "warp",
  "wiremock",
@@ -3256,6 +3257,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8db7427f936968176eaa7cdf81b7f98b980b18495ec28f1b5791ac3bfe3eea9"
 
 [[package]]
 name = "utf-8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ prost = "0.11.5"
 tokio = {version = "1.0.0", default-features = false, features = ["io-util", "io-std", "macros", "net", "rt-multi-thread", "time", "sync"]}
 warp = "0.3"
 tokio-tungstenite = "0.18.0"
+urlencoding = "2.1.2"
 
 [build-dependencies]
 dcl-rpc = "1.0.0"

--- a/src/components/synapse.rs
+++ b/src/components/synapse.rs
@@ -275,10 +275,11 @@ impl SynapseComponent {
     pub async fn set_account_data(
         &self,
         token: &str,
-        user_id: &str,
+        synapse_user_id: &str,
         direct_room_map: HashMap<String, Vec<String>>,
     ) -> Result<(), CommonError> {
-        let path: String = format!("/_matrix/client/r0/user/{user_id}/account_data/m.direct");
+        let path: String =
+            format!("/_matrix/client/r0/user/{synapse_user_id}/account_data/m.direct");
 
         Self::authenticated_put_request(&path, token, &self.synapse_url, direct_room_map).await
     }
@@ -288,9 +289,10 @@ impl SynapseComponent {
     pub async fn get_account_data(
         &self,
         token: &str,
-        user_id: &str,
+        synapse_user_id: &str,
     ) -> Result<AccountDataContentResponse, CommonError> {
-        let path: String = format!("/_matrix/client/r0/user/{user_id}/account_data/m.direct");
+        let path: String =
+            format!("/_matrix/client/r0/user/{synapse_user_id}/account_data/m.direct");
 
         Self::authenticated_get_request(&path, token, &self.synapse_url).await
     }

--- a/src/components/synapse.rs
+++ b/src/components/synapse.rs
@@ -439,7 +439,13 @@ pub fn clean_synapse_user_id(user_id: &str) -> String {
 /// `zone`.
 pub fn extract_domain(url: &str) -> &str {
     let splited_domain: Vec<&str> = url.split('.').collect();
-    splited_domain.last().unwrap_or(&"zone")
+    let last_part = splited_domain.last().unwrap_or(&"zone");
+
+    if last_part == &"zone" || last_part == &"org" {
+        last_part
+    } else {
+        "zone"
+    }
 }
 
 /// Gets the synapse user id for the given user id

--- a/src/components/synapse.rs
+++ b/src/components/synapse.rs
@@ -249,12 +249,12 @@ impl SynapseComponent {
     pub async fn create_private_room(
         &self,
         token: &str,
-        user_ids: Vec<&str>,
+        synapse_user_ids: Vec<&str>,
         room_alias_name: &str,
     ) -> Result<CreateRoomResponse, CommonError> {
         let path = "/_matrix/client/r0/createRoom".to_string();
 
-        let invite = user_ids.iter().map(|id| id.to_string()).collect();
+        let invite = synapse_user_ids.iter().map(|id| id.to_string()).collect();
 
         Self::authenticated_post_request(
             &path,

--- a/src/ws/service/synapse_handler.rs
+++ b/src/ws/service/synapse_handler.rs
@@ -25,12 +25,12 @@ use super::errors::{FriendshipsServiceError, FriendshipsServiceErrorResponse};
 /// * `second_user` - The address of the second user.
 /// * `synapse_url` -
 ///
-/// Returns the room alias name as a string.
+/// Returns the encoded room alias name as a string, created from the sorted and joined user addresses.
 fn build_room_alias_name(acting_user: &str, second_user: &str, synapse_url: &str) -> String {
-    let act_user_parsed = encode(&format!("#{acting_user}")).into_owned();
+    let act_user_parsed = encode(&format!("#{}", acting_user.to_ascii_lowercase())).into_owned();
     let sec_user_parsed: String = encode(&format!(
         "{}:decentraland.{}",
-        second_user,
+        second_user.to_ascii_lowercase(),
         extract_domain(synapse_url)
     ))
     .into_owned();

--- a/src/ws/service/synapse_handler.rs
+++ b/src/ws/service/synapse_handler.rs
@@ -27,18 +27,19 @@ use super::errors::{FriendshipsServiceError, FriendshipsServiceErrorResponse};
 ///
 /// Returns the encoded room alias name as a string, created from the sorted and joined user addresses.
 fn build_room_alias_name(acting_user: &str, second_user: &str, synapse_url: &str) -> String {
-    let act_user_parsed = encode(&format!("#{}", acting_user.to_ascii_lowercase())).into_owned();
-    let sec_user_parsed: String = encode(&format!(
+    let act_user_parsed = format!("#{}", acting_user.to_ascii_lowercase());
+    let sec_user_parsed: String = format!(
         "{}:decentraland.{}",
         second_user.to_ascii_lowercase(),
         extract_domain(synapse_url)
-    ))
-    .into_owned();
+    );
 
-    let mut addrs = vec![act_user_parsed, sec_user_parsed];
-    addrs.sort();
+    let mut addresses = vec![act_user_parsed, sec_user_parsed];
+    addresses.sort();
 
-    addrs.join("+")
+    let joined_addresses = addresses.join("+");
+
+    encode(&joined_addresses).into_owned()
 }
 
 /// Retrieves the User Id associated with the given Authentication Token.


### PR DESCRIPTION
- Fix `extract_domain` to return `zone` as default.
- Fix `build_room_alias_name` to follow synapse pattern.
- Define CreateRoomOpts preset as String instead of Enum