### PR TITLE
fix: `metadata` None when `room_message_body` None

### DIFF
--- a/src/api/routes/synapse/room_events.rs
+++ b/src/api/routes/synapse/room_events.rs
@@ -372,12 +372,10 @@ async fn update_friendship_status<'a>(
         }
     };
 
-    let metadata = room_info.room_message_body.map(|message| {
-        sqlx::types::Json(FriendshipMetadata {
-            message: Some(message.to_string()),
-            synapse_room_id: Some(room_info.room_id.to_string()),
-            migrated_from_synapse: None,
-        })
+    let metadata = sqlx::types::Json(FriendshipMetadata {
+        message: room_info.room_message_body.map(|m| m.to_string()),
+        synapse_room_id: Some(room_info.room_id.to_string()),
+        migrated_from_synapse: None,
     });
 
     // store history
@@ -387,7 +385,7 @@ async fn update_friendship_status<'a>(
             friendship_id,
             &room_event,
             acting_user,
-            metadata,
+            Some(metadata),
             Some(transaction),
         )
         .await;

--- a/src/ws/service/database_handler.rs
+++ b/src/ws/service/database_handler.rs
@@ -148,12 +148,10 @@ pub async fn update_friendship_status<'a>(
         }
     };
 
-    let metadata = room_info.room_message_body.map(|message| {
-        sqlx::types::Json(FriendshipMetadata {
-            message: Some(message.to_string()),
-            synapse_room_id: Some(room_info.room_id.to_string()),
-            migrated_from_synapse: None,
-        })
+    let metadata = sqlx::types::Json(FriendshipMetadata {
+        message: room_info.room_message_body.map(|m| m.to_string()),
+        synapse_room_id: Some(room_info.room_id.to_string()),
+        migrated_from_synapse: None,
     });
 
     // Store history
@@ -163,7 +161,7 @@ pub async fn update_friendship_status<'a>(
             friendship_id,
             &room_event,
             acting_user,
-            metadata,
+            Some(metadata),
             Some(transaction),
         )
         .await;


### PR DESCRIPTION
- Fix: when `room_message_body` is None, the closure passed to the map method will not be executed, and `metadata` will also be None. Now, `metadata` will always be a Json type wrapping a FriendshipMetadata object, even if `room_message_body` is None.

**The API seems to be working because we're getting a blank string in the metadata: `""` (whenever there is no an actual message), so the closure always gets executed.**