### PR TITLE
feat: handle transport disconnection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -677,9 +677,9 @@ dependencies = [
 
 [[package]]
 name = "dcl-rpc"
-version = "2.0.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f2cf12edb56aad35b1766bd85cffd8b9542da227b2645da15b7f9c89f237e96"
+checksum = "8d274fb5fd9899a9dbd9d30b69db470acb43f39b37069352c62f3f0680f47c1a"
 dependencies = [
  "async-channel",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ serde_json = "1.0.89"
 mockall = "0.11.3"
 lazy_static = "1.4.0"
 actix-http = "3.2.2"
-dcl-rpc = "2.0.1"
+dcl-rpc = "2.1.1"
 prost = "0.11.5"
 tokio = {version = "1.0.0", default-features = false, features = ["io-util", "io-std", "macros", "net", "rt-multi-thread", "time", "sync"]}
 warp = "0.3"
@@ -45,7 +45,7 @@ tokio-tungstenite = "0.18.0"
 urlencoding = "2.1.2"
 
 [build-dependencies]
-dcl-rpc = "2.0.1"
+dcl-rpc = "2.1.1"
 prost-build = "0.11.5"
 reqwest = { version = "0.11", features = ["json", "blocking"] }
 serde_json = "1.0.94"

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ async fn main() -> io::Result<()> {
         redis_publisher: ws_components.redis_publisher.clone(),
         redis_subscriber: ws_components.redis_subscriber.clone(),
         friendships_events_generators: ws_components.friendships_events_generators.clone(),
+        transport_context: ws_components.transport_context.clone(),
     };
     // Run RPC Websocket Transport
     let (rpc_server_handle, http_server_handle) = run_ws_transport(ctx).await;

--- a/src/ws/app.rs
+++ b/src/ws/app.rs
@@ -126,8 +126,7 @@ pub async fn run_ws_transport(
         let generators_clone = generators_clone.clone();
         tokio::spawn(async move {
             let transport_contexts_lock = transport_contexts_clone.read().await;
-            let transport_ctx = transport_contexts_lock.get(&transport_id);
-            if let Some(transport_ctx) = transport_ctx {
+            if let Some(transport_ctx) = transport_contexts_lock.get(&transport_id) {
                 generators_clone
                     .write()
                     .await

--- a/src/ws/app.rs
+++ b/src/ws/app.rs
@@ -169,8 +169,8 @@ pub async fn run_ws_transport(
 }
 
 async fn remove_transport_id_from_context(
-    transport_id: u32,
-    transport_contexts: Arc<RwLock<HashMap<u32, SocialTransportContext>>>,
+    transport_id: TransportId,
+    transport_contexts: Arc<RwLock<HashMap<TransportId, SocialTransportContext>>>,
     generators: Arc<
         RwLock<HashMap<Address, GeneratorYielder<SubscribeFriendshipEventsUpdatesResponse>>>,
     >,

--- a/src/ws/app.rs
+++ b/src/ws/app.rs
@@ -50,8 +50,10 @@ pub struct ConfigRpcServer {
 }
 
 pub struct SocialTransportContext {
-    pub address: String, // TODO: Change to Address
+    pub address: Address,
 }
+
+type TransportId = u32;
 
 pub struct SocialContext {
     pub synapse: SynapseComponent,
@@ -62,7 +64,7 @@ pub struct SocialContext {
     pub redis_subscriber: Arc<RedisChannelSubscriber>,
     pub friendships_events_generators:
         Arc<RwLock<HashMap<Address, GeneratorYielder<SubscribeFriendshipEventsUpdatesResponse>>>>,
-    pub transport_context: Arc<RwLock<HashMap<u32, SocialTransportContext>>>,
+    pub transport_context: Arc<RwLock<HashMap<TransportId, SocialTransportContext>>>,
 }
 
 pub struct WsComponents {
@@ -70,7 +72,7 @@ pub struct WsComponents {
     pub redis_subscriber: Arc<RedisChannelSubscriber>,
     pub friendships_events_generators:
         Arc<RwLock<HashMap<Address, GeneratorYielder<SubscribeFriendshipEventsUpdatesResponse>>>>,
-    pub transport_context: Arc<RwLock<HashMap<u32, SocialTransportContext>>>,
+    pub transport_context: Arc<RwLock<HashMap<TransportId, SocialTransportContext>>>,
 }
 
 pub async fn init_ws_components(config: Config) -> WsComponents {

--- a/src/ws/app.rs
+++ b/src/ws/app.rs
@@ -126,8 +126,8 @@ pub async fn run_ws_transport(
         let generators_clone = generators_clone.clone();
         tokio::spawn(async move {
             remove_transport_id_from_context(
-                transport_contexts_clone,
                 transport_id,
+                transport_contexts_clone,
                 generators_clone,
             )
             .await;
@@ -169,22 +169,19 @@ pub async fn run_ws_transport(
 }
 
 async fn remove_transport_id_from_context(
-    transport_contexts_clone: Arc<RwLock<HashMap<u32, SocialTransportContext>>>,
     transport_id: u32,
-    generators_clone: Arc<
+    transport_contexts: Arc<RwLock<HashMap<u32, SocialTransportContext>>>,
+    generators: Arc<
         RwLock<HashMap<Address, GeneratorYielder<SubscribeFriendshipEventsUpdatesResponse>>>,
     >,
 ) {
-    let transport_contexts_read_lock = transport_contexts_clone.read().await;
+    let transport_contexts_read_lock = transport_contexts.read().await;
     if let Some(transport_ctx) = transport_contexts_read_lock.get(&transport_id) {
         // First remove the generators of the corresponding address
-        generators_clone
-            .write()
-            .await
-            .remove(&transport_ctx.address);
+        generators.write().await.remove(&transport_ctx.address);
     };
     drop(transport_contexts_read_lock);
-    let mut transport_contexts_write_lock = transport_contexts_clone.write().await;
+    let mut transport_contexts_write_lock = transport_contexts.write().await;
     transport_contexts_write_lock.remove(&transport_id);
 }
 

--- a/src/ws/app.rs
+++ b/src/ws/app.rs
@@ -108,6 +108,9 @@ pub async fn run_ws_transport(
             friendships_service::MyFriendshipsService {},
         )
     });
+    // rpc_server.set_on_transport_closes_handler(async |_, transport_id| {
+    //     generators.write().await.remove(&transport_id);
+    // });
 
     // Get the Server Events Sender
     let server_events_sender = rpc_server.get_server_events_sender();

--- a/src/ws/service/friendships_service.rs
+++ b/src/ws/service/friendships_service.rs
@@ -233,10 +233,9 @@ impl FriendshipsServiceServer<SocialContext, FriendshipsServiceError> for MyFrie
             .write()
             .await
             .insert(
-                // TODO: handle this as a new Address type (#ISSUE: https://github.com/decentraland/social-service/issues/198)
                 context.transport_id,
                 SocialTransportContext {
-                    address: user_id.social_id.to_string(),
+                    address: Address(user_id.social_id.to_string()),
                 },
             );
 

--- a/src/ws/service/friendships_service.rs
+++ b/src/ws/service/friendships_service.rs
@@ -11,7 +11,7 @@ use crate::{
         SubscribeFriendshipEventsUpdatesResponse, UpdateFriendshipPayload,
         UpdateFriendshipResponse, User, Users,
     },
-    ws::app::SocialContext,
+    ws::app::{SocialContext, SocialTransportContext},
 };
 
 use super::{
@@ -224,6 +224,20 @@ impl FriendshipsServiceServer<SocialContext, FriendshipsServiceError> for MyFrie
         .await?;
 
         let (friendship_updates_generator, friendship_updates_yielder) = Generator::create();
+
+        // Attach transport_id to the context by transport
+        context
+            .server_context
+            .transport_context
+            .write()
+            .await
+            .insert(
+                // TODO: handle this as a new Address type (#ISSUE: https://github.com/decentraland/social-service/issues/198)
+                context.transport_id,
+                SocialTransportContext {
+                    address: user_id.social_id.to_string(),
+                },
+            );
 
         // Attach generator to the context by user_id
         context

--- a/src/ws/service/friendships_service.rs
+++ b/src/ws/service/friendships_service.rs
@@ -1,9 +1,6 @@
-use std::{
-    sync::Arc,
-    time::{SystemTime, UNIX_EPOCH},
-};
+use std::time::{SystemTime, UNIX_EPOCH};
 
-use dcl_rpc::stream_protocol::Generator;
+use dcl_rpc::{service_module_definition::ProcedureContext, stream_protocol::Generator};
 use futures_util::StreamExt;
 
 use crate::{
@@ -36,20 +33,20 @@ impl FriendshipsServiceServer<SocialContext, FriendshipsServiceError> for MyFrie
     async fn get_friends(
         &self,
         request: Payload,
-        context: Arc<SocialContext>,
+        context: ProcedureContext<SocialContext>,
     ) -> Result<ServerStreamResponse<Users>, FriendshipsServiceError> {
         // Get user id with the given Authentication Token.
         let user_id = get_user_id_from_request(
             &request,
-            context.synapse.clone(),
-            context.users_cache.clone(),
+            context.server_context.synapse.clone(),
+            context.server_context.users_cache.clone(),
         )
         .await?;
 
         let social_id = user_id.social_id.clone();
         log::info!("Getting all friends for user: {}", social_id);
         // Look for users friends
-        let mut friendship = match context.db.db_repos.clone() {
+        let mut friendship = match context.server_context.db.db_repos.clone() {
             Some(repos) => {
                 let friendship = repos
                     .friendships
@@ -113,20 +110,20 @@ impl FriendshipsServiceServer<SocialContext, FriendshipsServiceError> for MyFrie
     async fn get_request_events(
         &self,
         request: Payload,
-        context: Arc<SocialContext>,
+        context: ProcedureContext<SocialContext>,
     ) -> Result<RequestEvents, FriendshipsServiceError> {
         // Get user id with the given Authentication Token.
         let user_id = get_user_id_from_request(
             &request,
-            context.synapse.clone(),
-            context.users_cache.clone(),
+            context.server_context.synapse.clone(),
+            context.server_context.users_cache.clone(),
         )
         .await?;
 
         let social_id = user_id.social_id.clone();
         log::info!("Getting requests events for user: {}", social_id);
         // Look for users requests
-        match context.db.db_repos.clone() {
+        match context.server_context.db.db_repos.clone() {
             Some(repos) => {
                 let requests = repos
                     .friendship_history
@@ -159,7 +156,7 @@ impl FriendshipsServiceServer<SocialContext, FriendshipsServiceError> for MyFrie
     async fn update_friendship_event(
         &self,
         request: UpdateFriendshipPayload,
-        context: Arc<SocialContext>,
+        context: ProcedureContext<SocialContext>,
     ) -> Result<UpdateFriendshipResponse, FriendshipsServiceError> {
         // Get user id with the given Authentication Token.
         let auth_token = request.clone().auth_token.take().ok_or_else(|| {
@@ -167,15 +164,18 @@ impl FriendshipsServiceServer<SocialContext, FriendshipsServiceError> for MyFrie
         })?;
         let user_id = get_user_id_from_request(
             &auth_token,
-            context.synapse.clone(),
-            context.users_cache.clone(),
+            context.server_context.synapse.clone(),
+            context.server_context.users_cache.clone(),
         )
         .await?;
 
         // Handle friendship event update
-        let friendship_update_response =
-            handle_friendship_update(request.clone(), context.clone(), user_id.clone().social_id)
-                .await?;
+        let friendship_update_response = handle_friendship_update(
+            request.clone(),
+            context.server_context.clone(),
+            user_id.clone().social_id,
+        )
+        .await?;
 
         // Convert event response to update response
         let update_response =
@@ -187,7 +187,7 @@ impl FriendshipsServiceServer<SocialContext, FriendshipsServiceError> for MyFrie
             .unwrap()
             .as_secs() as i64;
 
-        let publisher = context.redis_publisher.clone();
+        let publisher = context.server_context.redis_publisher.clone();
         if let Some(event) = request.clone().event {
             tokio::spawn(async move {
                 if let Some(update_friendship_payload_as_event) = update_friendship_payload_as_event(
@@ -210,7 +210,7 @@ impl FriendshipsServiceServer<SocialContext, FriendshipsServiceError> for MyFrie
     async fn subscribe_friendship_events_updates(
         &self,
         request: Payload,
-        context: Arc<SocialContext>,
+        context: ProcedureContext<SocialContext>,
     ) -> Result<
         ServerStreamResponse<SubscribeFriendshipEventsUpdatesResponse>,
         FriendshipsServiceError,
@@ -218,19 +218,24 @@ impl FriendshipsServiceServer<SocialContext, FriendshipsServiceError> for MyFrie
         // Get user id with the given Authentication Token.
         let user_id = get_user_id_from_request(
             &request,
-            context.synapse.clone(),
-            context.users_cache.clone(),
+            context.server_context.synapse.clone(),
+            context.server_context.users_cache.clone(),
         )
         .await?;
 
         let (friendship_updates_generator, friendship_updates_yielder) = Generator::create();
 
         // Attach generator to the context by user_id
-        context.friendships_events_generators.write().await.insert(
-            // TODO: handle this as a new Address type (#ISSUE: https://github.com/decentraland/social-service/issues/198)
-            user_id.social_id.to_lowercase(),
-            friendship_updates_yielder.clone(),
-        );
+        context
+            .server_context
+            .friendships_events_generators
+            .write()
+            .await
+            .insert(
+                // TODO: handle this as a new Address type (#ISSUE: https://github.com/decentraland/social-service/issues/198)
+                user_id.social_id.to_lowercase(),
+                friendship_updates_yielder.clone(),
+            );
 
         // TODO: Remove generator from map when user has disconnected
         Ok(friendship_updates_generator)


### PR DESCRIPTION
Changes:
- Bump RPC lib to `2.1.1`
- Added `SocialTransportContext` to `SocialContext` to handle all context specific to a transport
- Added `Address` to `SocialTransportContext` to link `transport_id` to `user_id`
- Remove generators of subscriptions from `SocialContext` when a transport disconnects


Fixes https://github.com/decentraland/social-service/issues/200