### PR TITLE
Use consistent created_at

### DIFF
--- a/src/ws/service/friendships_service.rs
+++ b/src/ws/service/friendships_service.rs
@@ -286,9 +286,15 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
                                         return Ok(err.into());
                                     }
                                     Ok(friendship_update_response) => {
+                                        let created_at = SystemTime::now()
+                                            .duration_since(UNIX_EPOCH)
+                                            .unwrap()
+                                            .as_secs()
+                                            as i64;
                                         let update_response = event_response_as_update_response(
                                             request.clone(),
                                             friendship_update_response,
+                                            created_at,
                                         );
 
                                         match update_response {
@@ -297,13 +303,6 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
                                                 return Ok(err.into());
                                             }
                                             Ok(update_response) => {
-                                                // TODO: Use created_at from entity instead of calculating it again (#ISSUE: https://github.com/decentraland/social-service/issues/197)
-                                                let created_at = SystemTime::now()
-                                                    .duration_since(UNIX_EPOCH)
-                                                    .unwrap()
-                                                    .as_secs()
-                                                    as i64;
-
                                                 let publisher =
                                                     context.server_context.redis_publisher.clone();
                                                 if let Some(event) = request.clone().event {

--- a/src/ws/service/mapper/event.rs
+++ b/src/ws/service/mapper/event.rs
@@ -1,5 +1,3 @@
-use std::time::{SystemTime, UNIX_EPOCH};
-
 use crate::{
     domain::{
         error::CommonError,
@@ -149,6 +147,7 @@ pub fn update_request_as_event_payload(
 pub fn event_response_as_update_response(
     request: UpdateFriendshipPayload,
     result: EventResponse,
+    created_at: i64,
 ) -> Result<UpdateFriendshipResponse, CommonError> {
     let update_response = if let Some(body) = request.event {
         match body.body {
@@ -157,10 +156,7 @@ pub fn event_response_as_update_response(
                     user: Some(User {
                         address: result.user_id,
                     }),
-                    created_at: SystemTime::now()
-                        .duration_since(UNIX_EPOCH)
-                        .unwrap()
-                        .as_secs() as i64,
+                    created_at,
                     message: payload.message,
                 };
 

--- a/tests/ws_service_friendship_service.rs
+++ b/tests/ws_service_friendship_service.rs
@@ -138,7 +138,7 @@ mod tests {
             user_id: "Pizarnik".to_owned(),
         };
 
-        let result = event_response_as_update_response(update_payload, event_response);
+        let result = event_response_as_update_response(update_payload, event_response, 1);
         assert!(result.is_ok());
 
         let update_response = result


### PR DESCRIPTION
Use the entity's created_at field instead of re-calculating it

Fixes https://github.com/decentraland/social-service/issues/197