### PR TITLE
fix: set account data

### DIFF
--- a/src/components/synapse.rs
+++ b/src/components/synapse.rs
@@ -288,8 +288,8 @@ impl SynapseComponent {
             .await;
 
         match result {
-            Ok(_) => Ok(()),  // if successful, we just return Ok(())
-            Err(e) => Err(e), // if there was an error, we forward it
+            Ok(_) => Ok(()),
+            Err(e) => Err(e),
         }
     }
 

--- a/src/components/synapse.rs
+++ b/src/components/synapse.rs
@@ -386,7 +386,7 @@ impl SynapseComponent {
             Ok(response) => {
                 let text = response.text().await;
                 if let Err(err) = text {
-                    log::warn!("error reading synapse response {}", err);
+                    log::warn!("[Synapse] error reading synapse response {}", err);
                     return Err(CommonError::Unknown("".to_owned()));
                 }
 
@@ -396,7 +396,7 @@ impl SynapseComponent {
                 response.map_err(|_| Self::parse_and_return_error(&text))
             }
             Err(err) => {
-                log::warn!("error connecting to synapse {}", err);
+                log::warn!("[Synapse] error connecting to synapse {}", err);
                 Err(CommonError::Unknown("".to_owned()))
             }
         }

--- a/src/components/synapse.rs
+++ b/src/components/synapse.rs
@@ -278,7 +278,19 @@ impl SynapseComponent {
         let path: String =
             format!("/_matrix/client/r0/user/{synapse_user_id}/account_data/m.direct");
 
-        Self::authenticated_put_request(&path, token, &self.synapse_url, direct_room_map).await
+        let result: Result<HashMap<String, Vec<String>>, _> =
+            Self::authenticated_put_request::<HashMap<String, Vec<String>>, _>(
+                &path,
+                token,
+                &self.synapse_url,
+                direct_room_map,
+            )
+            .await;
+
+        match result {
+            Ok(_) => Ok(()),  // if successful, we just return Ok(())
+            Err(e) => Err(e), // if there was an error, we forward it
+        }
     }
 
     /// Retrieves the account data content for the given user id

--- a/src/synapse/synapse_handler.rs
+++ b/src/synapse/synapse_handler.rs
@@ -66,7 +66,7 @@ pub async fn store_message_in_synapse_room<'a>(
                     }
                     Err(err) => {
                         if retry_count == 2 {
-                            log::error!("Store message in synapse room > Error {err}");
+                            log::error!("[RPC] Store message in synapse room > Error {err}");
                             return Err(err);
                         }
                     }
@@ -92,7 +92,7 @@ pub async fn store_room_event_in_synapse_room(
     match res {
         Ok(_) => Ok(()),
         Err(err) => {
-            log::error!("Store room event in synapse room > Error {err}");
+            log::error!("[RPC] Store room event in synapse room > Error {err}");
             Err(err)
         }
     }
@@ -123,7 +123,7 @@ async fn create_private_room_in_synapse(
             Ok(res)
         }
         Err(err) => {
-            log::error!("Create private room in synapse > Error {err}");
+            log::error!("[RPC] Create private room in synapse > Error {err}");
             Err(err)
         }
     }
@@ -139,7 +139,7 @@ async fn get_room_id_for_alias_in_synapse(
     match res {
         Ok(response) => Ok(response.room_id),
         Err(err) => {
-            log::error!("Get room id for alias in synapse > Error {err}");
+            log::error!("[RPC] Get room id for alias in synapse > Error {err}");
             Err(err)
         }
     }
@@ -192,7 +192,7 @@ pub async fn get_or_create_synapse_room_id(
                     }
                 }
             } else {
-                log::error!("Get or create synapse room > Friendship does not exists and the event is different than Request");
+                log::error!("[RPC] Get or create synapse room > Friendship does not exists and the event is different than Request");
                 Err(CommonError::BadRequest(
                     "Invalid frienship event update".to_owned(),
                 ))
@@ -239,7 +239,9 @@ pub async fn set_account_data(
                         .set_account_data(token, &acting_user_as_synapse_id, direct_room_map)
                         .await
                         .map_err(|err| {
-                            log::error!("Set account data > Error setting account data {err}");
+                            log::error!(
+                                "[RPC] Set account data > Error setting account data {err}"
+                            );
                             err
                         })?;
                     return Ok(());
@@ -248,7 +250,7 @@ pub async fn set_account_data(
             Ok(())
         }
         Err(err) => {
-            log::error!("Set account data > Error getting account data {err}");
+            log::error!("[RPC] Set account data > Error getting account data {err}");
             Err(err)
         }
     }

--- a/src/ws/app.rs
+++ b/src/ws/app.rs
@@ -220,7 +220,7 @@ async fn send_update_to_corresponding_generator(
 
         if let Some(generator) = generators_lock.get(&corresponding_user_id) {
             if generator.r#yield(response.clone()).await.is_err() {
-                log::error!("Event Update received > Couldn't send update to subscriptors. Update: {:?}, Subscriptor: {:?}", response, &corresponding_user_id);
+                log::error!("[RPC] Event Update received > Couldn't send update to subscriptors. Update: {:?}, Subscriptor: {:?}", response, &corresponding_user_id);
             }
         }
     }

--- a/src/ws/service/friendship_event_updates.rs
+++ b/src/ws/service/friendship_event_updates.rs
@@ -31,7 +31,7 @@ pub async fn handle_friendship_update(
     let second_user = event_payload.second_user;
 
     let db_repos = context.db.clone().db_repos.ok_or_else(|| {
-        log::error!("Handle friendship update > Db repositories > `repos` is None.");
+        log::error!("[RPC] Handle friendship update > Db repositories > `repos` is None.");
         CommonError::Unknown("".to_owned())
     })?;
 
@@ -79,7 +79,7 @@ pub async fn handle_friendship_update(
     let transaction = match friendship_ports.db.start_transaction().await {
         Ok(tx) => tx,
         Err(error) => {
-            log::error!("Handle friendship update > Couldn't start transaction to store friendship update {error}");
+            log::error!("[RPC] Handle friendship update > Couldn't start transaction to store friendship update {error}");
             return Err(CommonError::Unknown("".to_owned()));
         }
     };
@@ -126,7 +126,7 @@ pub async fn handle_friendship_update(
     // End transaction
     if let Err(err) = transaction.commit().await {
         log::error!(
-            "Handle friendship update > Couldn't end transaction to store friendship update {err}"
+            "[RPC] Handle friendship update > Couldn't end transaction to store friendship update {err}"
         );
         Err(CommonError::Unknown("".to_owned()))
     } else {

--- a/src/ws/service/friendships_service.rs
+++ b/src/ws/service/friendships_service.rs
@@ -330,7 +330,7 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
                                                                 .publish(update_friendship_payload_as_event)
                                                                 .await;
                                                         } else {
-                                                            log::error!("There was an error parsing from friendship payload to event")
+                                                            log::error!("[RPC] There was an error parsing from friendship payload to event")
                                                         }
                                                     });
                                                 };
@@ -377,7 +377,7 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
 
                 let result = friendships_yielder.r#yield(err.into()).await;
                 if let Err(err) = result {
-                    log::error!("There was an error yielding the error to the subscribe friendships generator: {:?}", err);
+                    log::error!("[RPC] There was an error yielding the error to the subscribe friendships generator: {:?}", err);
                 };
             }
             Ok(user_id) => {
@@ -423,12 +423,12 @@ pub async fn get_user_id_from_request(
         Some(token) => get_user_id_from_token(synapse.clone(), users_cache.clone(), &token)
             .await
             .map_err(|err| {
-                log::error!("Get user id from request > Error {err}");
+                log::error!("[RPC] Get user id from request > Error {err}");
                 err
             }),
         // If no authentication token was provided, return an Unauthorized error.
         None => {
-            log::error!("Get user id from request > `synapse_token` is None.");
+            log::error!("[RPC] Get user id from request > `synapse_token` is None.");
             Err(CommonError::Unauthorized(
                 "`synapse_token` was not provided".to_owned(),
             ))

--- a/src/ws/service/mapper/payload.rs
+++ b/src/ws/service/mapper/payload.rs
@@ -4,14 +4,14 @@ pub fn get_synapse_token(request: UpdateFriendshipPayload) -> Result<String, Com
     let Some(auth_token) = request
       .auth_token
       .as_ref() else {
-          log::error!("Handle friendship update > `auth_token` is missing.");
+          log::error!("[RPC] Handle friendship update > `auth_token` is missing.");
           return Err(CommonError::Unauthorized("`auth_token` is missing".to_owned()));
       };
 
     let Some(synapse_token) = auth_token
       .synapse_token
       .as_ref() else {
-          log::error!("Handle friendship update > `synapse_token` is missing.");
+          log::error!("[RPC] Handle friendship update > `synapse_token` is missing.");
           return Err(CommonError::Unauthorized("`synapse_token` is missing".to_owned()))
       };
     Ok(synapse_token.to_string())

--- a/src/ws/transport.rs
+++ b/src/ws/transport.rs
@@ -42,7 +42,7 @@ impl Transport for WarpWebSocketTransport {
                     return Ok(message_data);
                 } else {
                     // Ignore messages that are not binary
-                    log::error!("> WebSocketTransport > Received message is not binary");
+                    log::error!("[RPC] WebSocketTransport > Received message is not binary");
                     return Err(TransportError::NotBinaryMessage);
                 }
             }
@@ -63,7 +63,7 @@ impl Transport for WarpWebSocketTransport {
         match self.write.lock().await.send(message).await {
             Err(err) => {
                 log::error!(
-                    "> WebSocketTransport > Error on sending in a ws connection {}",
+                    "[RPC] WebSocketTransport > Error on sending in a ws connection {}",
                     err.to_string()
                 );
 
@@ -81,7 +81,7 @@ impl Transport for WarpWebSocketTransport {
                 self.ready.store(false, Ordering::SeqCst);
             }
             _ => {
-                log::error!("Couldn't close transport")
+                log::error!("[RPC] Couldn't close transport")
             }
         }
     }

--- a/tests/component_database.rs
+++ b/tests/component_database.rs
@@ -207,7 +207,7 @@ async fn should_run_transaction_succesfully() {
         Ok(read) => {
             assert!(read.is_none())
         }
-        Err(err) => panic!("Failed while reading from db {}", err),
+        Err(err) => panic!("Failed while reading from db {err}"),
     }
 
     let (read, trans) = dbrepos.friendships.get_friendship(addresses, trans).await;
@@ -216,7 +216,7 @@ async fn should_run_transaction_succesfully() {
         Ok(read) => {
             assert!(read.is_some())
         }
-        Err(err) => panic!("Failed while reading from db {}", err),
+        Err(err) => panic!("Failed while reading from db {err}"),
     }
 
     trans.unwrap().commit().await.unwrap();
@@ -227,7 +227,7 @@ async fn should_run_transaction_succesfully() {
         Ok(read) => {
             assert!(read.is_some())
         }
-        Err(err) => panic!("Failed while reading from db {}", err),
+        Err(err) => panic!("Failed while reading from db {err}"),
     }
 }
 
@@ -238,7 +238,7 @@ async fn create_friendship(
     address_2: &str,
     is_active: bool,
 ) -> Uuid {
-    let synapse_room_id = format!("room_id_{}_{}", address_1, address_2);
+    let synapse_room_id = format!("room_id_{address_1}_{address_2}");
     dbrepos
         .friendships
         .create_new_friendships((address_1, address_2), is_active, &synapse_room_id, None)


### PR DESCRIPTION
Fixes #232 

When trying to set the account data for the user sometimes we were getting the error `invalid type: map, expected unit`. I've specified the type we need `HashMap<String, Vec<String>>` when calling the function `authenticated_put_request`