### PR TITLE
fix: filter only inactive when querying pending requests

### DIFF
--- a/src/entities/queries.rs
+++ b/src/entities/queries.rs
@@ -44,12 +44,14 @@ WHERE
 
 /// This query fetches the rows where the lastest event of a friendship_id is a REQUEST,
 /// and either address_1 or address_2 is equal to the given user's address.
+/// As there were tests cases that the request and accept event collided in timestamp, the guard to check if the friendship is inactive is needed
 pub const USER_REQUESTS_QUERY: &str =
     "SELECT f.address_1, f.address_2, fh.acting_user, fh.timestamp, fh.metadata
       FROM friendships f
       INNER JOIN friendship_history fh ON f.id = fh.friendship_id
       WHERE (LOWER(f.address_1) = LOWER($1) OR LOWER(f.address_2) = LOWER($1))
       AND fh.event = '\"request\"'
+      AND f.is_active IS FALSE
       AND fh.timestamp = (
         SELECT MAX(fh2.timestamp)
         FROM friendship_history fh2


### PR DESCRIPTION
fixes: https://github.com/decentraland/social-service/issues/237