### PR TITLE
feat: add ws metrics

### DIFF
--- a/src/domain/friendship_event.rs
+++ b/src/domain/friendship_event.rs
@@ -16,6 +16,18 @@ pub enum FriendshipEvent {
     DELETE, // Delete an existing friendship
 }
 
+impl FriendshipEvent {
+    pub fn as_str(&self) -> &'static str {
+        match *self {
+            FriendshipEvent::REQUEST => "request",
+            FriendshipEvent::CANCEL => "cancel",
+            FriendshipEvent::ACCEPT => "accept",
+            FriendshipEvent::REJECT => "reject",
+            FriendshipEvent::DELETE => "delete",
+        }
+    }
+}
+
 lazy_static::lazy_static! {
     static ref VALID_FRIENDSHIP_EVENT_TRANSITIONS: HashMap<FriendshipEvent, Vec<Option<FriendshipEvent>>> = {
         let mut m = HashMap::new();

--- a/src/ws/app.rs
+++ b/src/ws/app.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::Arc, time::Instant};
+use std::{collections::HashMap, sync::Arc};
 
 use dcl_rpc::{
     server::RpcServer,
@@ -255,10 +255,9 @@ async fn send_update_to_corresponding_generator(
     if let Some(response) = event_as_friendship_update_response(event_update.clone()) {
         let corresponding_user_id = Address(event_update.to.to_lowercase());
 
-        metrics.record_procedure_call_and_duration_and_out_size(
+        metrics.record_out_procedure_call_size(
             None,
             Procedure::SubscribeFriendshipEventsUpdates,
-            Instant::now(),
             response.encoded_len(),
         );
 

--- a/src/ws/app.rs
+++ b/src/ws/app.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, sync::Arc, time::Instant};
 
 use dcl_rpc::{
     server::RpcServer,

--- a/src/ws/app.rs
+++ b/src/ws/app.rs
@@ -36,7 +36,7 @@ use crate::{
 use super::{
     metrics::{
         decrement_connected_clients, increment_connected_clients, metrics_handler,
-        record_procedure_call_and_duration_and_size, validate_bearer_token, Metrics, Procedure,
+        record_procedure_call_and_duration_and_out_size, validate_bearer_token, Metrics, Procedure,
     },
     service::friendships_service,
 };
@@ -249,7 +249,7 @@ async fn send_update_to_corresponding_generator(
     if let Some(response) = event_as_friendship_update_response(event_update.clone()) {
         let corresponding_user_id = Address(event_update.to.to_lowercase());
 
-        record_procedure_call_and_duration_and_size(
+        record_procedure_call_and_duration_and_out_size(
             metrics,
             None,
             Procedure::SubscribeFriendshipEventsUpdates,

--- a/src/ws/app.rs
+++ b/src/ws/app.rs
@@ -128,10 +128,13 @@ pub async fn run_ws_transport(
         )
     });
 
+    let metrics_clone = Arc::clone(&metrics);
     rpc_server.set_on_transport_closes_handler(move |_, transport_id| {
         let transport_contexts_clone = transport_contexts.clone();
         let generators_clone = generators_clone.clone();
+        let metrics_clone = metrics_clone.clone();
         tokio::spawn(async move {
+            decrement_connected_clients(metrics_clone).await;
             remove_transport_id_from_context(
                 transport_id,
                 transport_contexts_clone,

--- a/src/ws/metrics.rs
+++ b/src/ws/metrics.rs
@@ -137,6 +137,88 @@ impl Metrics {
         let opts = HistogramOpts::new(metric.0, metric.1);
         HistogramVec::new(opts, labels)
     }
+
+    /// Records a procedure call. This increments the counter of procedure calls
+    /// based on the response code and the specific procedure.
+    fn record_procedure_call(&self, code: Option<WsServiceError>, procedure: Procedure) {
+        let code = map_error_code(code);
+        self.procedure_call_total_collector
+            .with_label_values(&[code, procedure.as_str()])
+            .inc();
+    }
+
+    /// Increments the count of connected clients.
+    pub fn increment_connected_clients(&self) {
+        self.connected_clients_total_collector.inc();
+    }
+
+    /// Decrements the count of connected clients.
+    pub fn decrement_connected_clients(&self) {
+        self.connected_clients_total_collector.dec();
+    }
+
+    /// Records updates sent on subscription.
+    /// This increments the counter of updates sent
+    /// on subscription based on the event type.
+    pub fn record_friendship_event_updates_sent(&self, event: FriendshipEvent) {
+        self.updates_sent_on_subscription_total_collector
+            .with_label_values(&[event.as_str()])
+            .inc();
+    }
+
+    /// Records the size of the incoming payload of a procedure call.
+    /// This adds the size of the procedure call incoming payload to the
+    /// histogram for the specified procedure.
+    pub fn record_in_procedure_call_size<T: prost::Message>(&self, procedure: Procedure, msg: &T) {
+        let size = calculate_message_size(msg);
+        self.in_procedure_call_size_bytes_histogram_collector
+            .with_label_values(&[procedure.as_str()])
+            .observe(size as f64);
+    }
+
+    /// Records the size of the outgoing payload of a procedure call.
+    /// This adds the size of the procedure call outgoing payload to the
+    /// histogram for the specified procedure and response code.
+    fn record_out_procedure_call_size(
+        &self,
+        code: Option<WsServiceError>,
+        procedure: Procedure,
+        size: usize,
+    ) {
+        let code = map_error_code(code);
+        self.out_procedure_call_size_bytes_histogram_collector
+            .with_label_values(&[code, procedure.as_str()])
+            .observe(size as f64);
+    }
+
+    /// Records the duration of a procedure call.
+    /// This adds the duration of the procedure call to the
+    /// histogram for the specified procedure and response code.
+    fn record_request_procedure_call_duration(
+        &self,
+        code: Option<WsServiceError>,
+        procedure: Procedure,
+        start_time: Instant,
+    ) {
+        let code = map_error_code(code);
+        let duration = Instant::now().duration_since(start_time).as_secs_f64();
+        self.procedure_call_duration_seconds_histogram_collector
+            .with_label_values(&[code, procedure.as_str()])
+            .observe(duration);
+    }
+
+    /// Records a procedure call, its duration and its outgoing payload size.
+    pub fn record_procedure_call_and_duration_and_out_size(
+        &self,
+        code: Option<WsServiceError>,
+        procedure: Procedure,
+        start_time: Instant,
+        size: usize,
+    ) {
+        self.record_procedure_call(code.clone(), procedure.clone());
+        self.record_request_procedure_call_duration(code.clone(), procedure.clone(), start_time);
+        self.record_out_procedure_call_size(code, procedure, size);
+    }
 }
 
 #[derive(Debug)]
@@ -161,107 +243,6 @@ impl Procedure {
             Procedure::SubscribeFriendshipEventsUpdates => "SubscribeFriendshipEventsUpdates",
         }
     }
-}
-
-/// Records a procedure call. This increments the counter of procedure calls
-/// based on the response code and the specific procedure.
-async fn record_procedure_call(
-    metrics: Arc<Metrics>,
-    code: Option<WsServiceError>,
-    procedure: Procedure,
-) {
-    let code = map_error_code(code);
-    metrics
-        .procedure_call_total_collector
-        .with_label_values(&[code, procedure.as_str()])
-        .inc();
-}
-
-/// Increments the count of connected clients.
-pub async fn increment_connected_clients(metrics: Arc<Metrics>) {
-    metrics.connected_clients_total_collector.inc();
-}
-
-/// Decrements the count of connected clients.
-pub async fn decrement_connected_clients(metrics: Arc<Metrics>) {
-    metrics.connected_clients_total_collector.dec();
-}
-
-/// Records updates sent on subscription.
-/// This increments the counter of updates sent
-/// on subscription based on the event type.
-pub async fn record_friendship_event_updates_sent(metrics: Arc<Metrics>, event: FriendshipEvent) {
-    metrics
-        .updates_sent_on_subscription_total_collector
-        .with_label_values(&[event.as_str()])
-        .inc();
-}
-
-/// Records the size of the incoming payload of a procedure call.
-/// This adds the size of the procedure call incoming payload to the
-/// histogram for the specified procedure.
-pub async fn record_in_procedure_call_size<T: prost::Message>(
-    metrics: Arc<Metrics>,
-    procedure: Procedure,
-    msg: &T,
-) {
-    let size = calculate_message_size(msg);
-    metrics
-        .in_procedure_call_size_bytes_histogram_collector
-        .with_label_values(&[procedure.as_str()])
-        .observe(size as f64);
-}
-
-/// Records the size of the outgoing payload of a procedure call.
-/// This adds the size of the procedure call outgoing payload to the
-/// histogram for the specified procedure and response code.
-async fn record_out_procedure_call_size(
-    metrics: Arc<Metrics>,
-    code: Option<WsServiceError>,
-    procedure: Procedure,
-    size: usize,
-) {
-    let code = map_error_code(code);
-    metrics
-        .out_procedure_call_size_bytes_histogram_collector
-        .with_label_values(&[code, procedure.as_str()])
-        .observe(size as f64);
-}
-
-/// Records the duration of a procedure call.
-/// This adds the duration of the procedure call to the
-/// histogram for the specified procedure and response code.
-async fn record_request_procedure_call_duration(
-    metrics: Arc<Metrics>,
-    code: Option<WsServiceError>,
-    procedure: Procedure,
-    start_time: Instant,
-) {
-    let code = map_error_code(code);
-    let duration = Instant::now().duration_since(start_time).as_secs_f64();
-    metrics
-        .procedure_call_duration_seconds_histogram_collector
-        .with_label_values(&[code, procedure.as_str()])
-        .observe(duration);
-}
-
-/// Records a procedure call, its duration and its outgoing payload size.
-pub async fn record_procedure_call_and_duration_and_out_size(
-    metrics: Arc<Metrics>,
-    code: Option<WsServiceError>,
-    procedure: Procedure,
-    start_time: Instant,
-    size: usize,
-) {
-    record_procedure_call(metrics.clone(), code.clone(), procedure.clone()).await;
-    record_request_procedure_call_duration(
-        metrics.clone(),
-        code.clone(),
-        procedure.clone(),
-        start_time,
-    )
-    .await;
-    record_out_procedure_call_size(metrics, code, procedure, size).await;
 }
 
 /// Calculates the size of the encoded message in bytes.

--- a/src/ws/metrics.rs
+++ b/src/ws/metrics.rs
@@ -5,12 +5,15 @@ use warp::{http::header::HeaderValue, reject::Reject, Rejection, Reply};
 
 use prometheus::{self, Encoder, IntCounterVec, IntGauge, Opts, Registry};
 
+use crate::domain::friendship_event::FriendshipEvent;
+
 use super::service::mapper::error::WsServiceError;
 
 #[derive(Clone)]
 pub struct Metrics {
     pub procedure_call_total_collector: IntCounterVec,
     pub connected_clients_total_collector: IntGauge,
+    pub updates_sent_on_subscription_total_collector: IntCounterVec,
     pub registry: Registry,
 }
 
@@ -20,26 +23,53 @@ impl Default for Metrics {
     }
 }
 
+const PROCEDURE_CALL_METRIC: (&str, &str) = (
+    "dcl_social_service_rpc_procedure_call_total",
+    "Social Service RPC Websocket Procedure Calls",
+);
+const CONNECTED_CLIENTS_METRIC: (&str, &str) = (
+    "dcl_social_service_rpc_connected_clients_total",
+    "Social Service RPC Websocket Connected Clients",
+);
+const UPDATES_SENT_METRIC: (&str, &str) = (
+    "dcl_social_service_rpc_updates_sent_on_subscription_total",
+    "Social Service RPC Websocket Updates Sent On Subscription",
+);
+
 impl Metrics {
     pub fn new() -> Self {
-        let opts = Opts::new(
-            "dcl_social_service_rpc_procedure_call_total",
-            "Social Service RPC Websocket Procedure Calls",
-        );
+        let procedure_call_total_collector =
+          Self::create_int_counter_vec(PROCEDURE_CALL_METRIC, &["code", "procedure"])
+          .expect("Metrics definition is correct, so dcl_social_service_rpc_procedure_call_total metric should be created successfully");
 
-        let procedure_call_total_collector = IntCounterVec::new(opts, &["code", "procedure"])
-            .expect("Metrics definition is correct, so dcl_social_service_rpc_procedure_call_total metric should be created successfully");
+        let connected_clients_total_collector =
+          Self::create_int_gauge(CONNECTED_CLIENTS_METRIC)
+          .expect("Metrics definition is correct, so dcl_social_service_rpc_connected_clients_total metric should be created successfully");
 
-        let connected_clients_total_collector = IntGauge::new("dcl_social_service_rpc_connected_clients_total", "Social Service RPC Websocket Connected Clients")
-            .expect("Metrics definition is correct, so dcl_social_service_rpc_connected_clients_total metric should be created successfully");
+        let updates_sent_on_subscription_total_collector =
+          Self::create_int_counter_vec(UPDATES_SENT_METRIC, &["event"])
+          .expect("Metrics definition is correct, so dcl_social_service_rpc_updates_sent_on_subscription_total metric should be created successfully");
 
         let registry = Registry::new();
 
         Metrics {
             procedure_call_total_collector,
             connected_clients_total_collector,
+            updates_sent_on_subscription_total_collector,
             registry,
         }
+    }
+
+    fn create_int_counter_vec(
+        metric: (&str, &str),
+        labels: &[&str],
+    ) -> Result<IntCounterVec, prometheus::Error> {
+        let opts = Opts::new(metric.0, metric.1);
+        IntCounterVec::new(opts, labels)
+    }
+
+    fn create_int_gauge(metric: (&str, &str)) -> Result<IntGauge, prometheus::Error> {
+        IntGauge::new(metric.0, metric.1)
     }
 }
 
@@ -98,6 +128,14 @@ pub async fn decrement_connected_clients(metrics: Arc<Mutex<Metrics>>) {
     metrics.connected_clients_total_collector.dec();
 }
 
+pub async fn record_updates_sent(metrics: Arc<Mutex<Metrics>>, event: FriendshipEvent) {
+    let metrics = metrics.lock().await;
+    metrics
+        .updates_sent_on_subscription_total_collector
+        .with_label_values(&[event.as_str()])
+        .inc();
+}
+
 pub async fn register_metrics(metrics: Arc<Mutex<Metrics>>) {
     log::info!("[RPC] Registering Social Service RPC Websocket metrics");
 
@@ -112,6 +150,11 @@ pub async fn register_metrics(metrics: Arc<Mutex<Metrics>>) {
         .registry
         .register(Box::new(metrics.connected_clients_total_collector.clone()))
         .expect("Connection Total Collector metrics should be correct, so CONNECTED_CLIENTS_COLLECTOR can be registered successfully");
+
+    metrics
+        .registry
+        .register(Box::new(metrics.updates_sent_on_subscription_total_collector.clone()))
+            .expect("Updates Sent On Subscription Total Collector metrics should be correct, so UPDATES_SENT_ON_SUBSCRIPTION_TOTAL_COLLECTOR can be registered successfully");
 
     log::info!("[RPC] Registered Social Service RPC Websocket metrics");
 }

--- a/src/ws/metrics.rs
+++ b/src/ws/metrics.rs
@@ -3,7 +3,9 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 use warp::{http::header::HeaderValue, reject::Reject, Rejection, Reply};
 
-use prometheus::{self, Encoder, IntCounterVec, IntGauge, Opts, Registry};
+use prometheus::{
+    self, Encoder, HistogramOpts, HistogramVec, IntCounterVec, IntGauge, Opts, Registry,
+};
 
 use crate::domain::friendship_event::FriendshipEvent;
 
@@ -14,6 +16,7 @@ pub struct Metrics {
     pub procedure_call_total_collector: IntCounterVec,
     pub connected_clients_total_collector: IntGauge,
     pub updates_sent_on_subscription_total_collector: IntCounterVec,
+    pub procedure_call_size_bytes_histogram_collector: HistogramVec,
     pub registry: Registry,
 }
 
@@ -36,6 +39,11 @@ const UPDATES_SENT_METRIC: (&str, &str) = (
     "Social Service RPC Websocket Updates Sent On Subscription",
 );
 
+const PROCEDURE_CALL_SIZE: (&str, &str) = (
+    "dcl_social_service_rpc_procedure_call_size_bytes_histogram",
+    "Social Service RPC Websocket Procedure Call Size",
+);
+
 impl Metrics {
     pub fn new() -> Self {
         let procedure_call_total_collector =
@@ -50,12 +58,17 @@ impl Metrics {
           Self::create_int_counter_vec(UPDATES_SENT_METRIC, &["event"])
           .expect("Metrics definition is correct, so dcl_social_service_rpc_updates_sent_on_subscription_total metric should be created successfully");
 
+        let procedure_call_size_bytes_histogram_collector =
+          Self::create_histogram_vec(PROCEDURE_CALL_SIZE, &["procedure"])
+          .expect("Metrics definition is correct, so dcl_social_service_rpc_procedure_call_size_bytes_histogram metric should be created successfully");
+
         let registry = Registry::new();
 
         Metrics {
             procedure_call_total_collector,
             connected_clients_total_collector,
             updates_sent_on_subscription_total_collector,
+            procedure_call_size_bytes_histogram_collector,
             registry,
         }
     }
@@ -70,6 +83,14 @@ impl Metrics {
 
     fn create_int_gauge(metric: (&str, &str)) -> Result<IntGauge, prometheus::Error> {
         IntGauge::new(metric.0, metric.1)
+    }
+
+    fn create_histogram_vec(
+        metric: (&str, &str),
+        labels: &[&str],
+    ) -> Result<HistogramVec, prometheus::Error> {
+        let opts = HistogramOpts::new(metric.0, metric.1);
+        HistogramVec::new(opts, labels)
     }
 }
 
@@ -96,44 +117,73 @@ impl Procedure {
     }
 }
 
+/// Records a procedure call. This increments the counter of procedure calls
+/// based on the response code and the specific procedure.
 pub async fn record_procedure_call(
     metrics: Arc<Mutex<Metrics>>,
     code: Option<WsServiceError>,
     procedure: Procedure,
 ) {
-    let code = match code {
-        Some(WsServiceError::Unauthorized(_)) => "UNAUTHORIZED_ERROR",
-        Some(WsServiceError::InternalServer(_)) => "INTERNAL_SERVER_ERROR",
-        Some(WsServiceError::BadRequest(_)) => "BAD_REQUEST_ERROR",
-        Some(WsServiceError::Forbidden(_)) => "FORBIDDEN_ERROR",
-        Some(WsServiceError::TooManyRequests(_)) => "TOO_MANY_REQUESTS_ERROR",
-        None => "OK",
-    };
-
+    let code = map_error_code(code);
     let metrics = metrics.lock().await;
-
     metrics
         .procedure_call_total_collector
         .with_label_values(&[code, procedure.as_str()])
         .inc();
 }
 
+/// Increments the count of connected clients.
 pub async fn increment_connected_clients(metrics: Arc<Mutex<Metrics>>) {
     let metrics = metrics.lock().await;
     metrics.connected_clients_total_collector.inc();
 }
 
+/// Decrements the count of connected clients.
 pub async fn decrement_connected_clients(metrics: Arc<Mutex<Metrics>>) {
     let metrics = metrics.lock().await;
     metrics.connected_clients_total_collector.dec();
 }
 
+/// Records updates sent on subscription. This increments the counter of updates sent
+/// on subscription based on the event type.
 pub async fn record_updates_sent(metrics: Arc<Mutex<Metrics>>, event: FriendshipEvent) {
     let metrics = metrics.lock().await;
     metrics
         .updates_sent_on_subscription_total_collector
         .with_label_values(&[event.as_str()])
         .inc();
+}
+
+/// Records the size of a procedure call. This adds the size of the procedure call to the
+/// histogram for the specified procedure.
+pub async fn record_procedure_call_size<T: prost::Message>(
+    metrics: Arc<Mutex<Metrics>>,
+    procedure: Procedure,
+    msg: &T,
+) {
+    let metrics = metrics.lock().await;
+    let size = calculate_message_size(msg);
+    metrics
+        .procedure_call_size_bytes_histogram_collector
+        .with_label_values(&[procedure.as_str()])
+        .observe(size as f64);
+}
+
+/// Calculates the size of the encoded message in bytes.
+fn calculate_message_size<T: prost::Message>(msg: &T) -> usize {
+    msg.encoded_len()
+}
+
+/// Maps a `WsServiceError` variant to a corresponding string representation.
+fn map_error_code(code: Option<WsServiceError>) -> &'static str {
+    match code {
+        Some(WsServiceError::Unauthorized(_)) => "UNAUTHORIZED_ERROR",
+        Some(WsServiceError::InternalServer(_)) => "INTERNAL_SERVER_ERROR",
+        Some(WsServiceError::BadRequest(_)) => "BAD_REQUEST_ERROR",
+        Some(WsServiceError::Forbidden(_)) => "FORBIDDEN_ERROR",
+        Some(WsServiceError::TooManyRequests(_)) => "TOO_MANY_REQUESTS_ERROR",
+        None => "OK",
+    }
 }
 
 pub async fn register_metrics(metrics: Arc<Mutex<Metrics>>) {
@@ -155,6 +205,11 @@ pub async fn register_metrics(metrics: Arc<Mutex<Metrics>>) {
         .registry
         .register(Box::new(metrics.updates_sent_on_subscription_total_collector.clone()))
             .expect("Updates Sent On Subscription Total Collector metrics should be correct, so UPDATES_SENT_ON_SUBSCRIPTION_TOTAL_COLLECTOR can be registered successfully");
+
+    metrics
+        .registry
+        .register(Box::new(metrics.procedure_call_size_bytes_histogram_collector.clone()))
+        .expect("Procedure Call Size Bytes Histogram Collector metrics should be correct, so PROCEDURE_CALL_SIZE_BYTES_HISTOGRAM_COLLECTOR can be registered successfully");
 
     log::info!("[RPC] Registered Social Service RPC Websocket metrics");
 }

--- a/src/ws/metrics.rs
+++ b/src/ws/metrics.rs
@@ -199,7 +199,7 @@ impl Metrics {
     /// Records the size of the outgoing payload of a procedure call.
     /// This adds the size of the procedure call outgoing payload to the
     /// histogram for the specified procedure and response code.
-    fn record_out_procedure_call_size(
+    pub fn record_out_procedure_call_size(
         &self,
         code: Option<WsServiceError>,
         procedure: Procedure,
@@ -225,6 +225,17 @@ impl Metrics {
         self.procedure_call_duration_seconds_histogram_collector
             .with_label_values(&[code, procedure.as_str()])
             .observe(duration);
+    }
+
+    /// Records a procedure call, its duration but not the size, useful for stream responses
+    pub fn record_procedure_call_and_duration(
+        &self,
+        code: Option<WsServiceError>,
+        procedure: Procedure,
+        start_time: Instant,
+    ) {
+        self.record_procedure_call(code.clone(), procedure.clone());
+        self.record_request_procedure_call_duration(code, procedure, start_time);
     }
 
     /// Records a procedure call, its duration and its outgoing payload size.

--- a/src/ws/metrics.rs
+++ b/src/ws/metrics.rs
@@ -246,7 +246,7 @@ async fn record_request_procedure_call_duration(
 }
 
 /// Records a procedure call, its duration and its outgoing payload size.
-pub async fn record_procedure_call_and_duration_and_size(
+pub async fn record_procedure_call_and_duration_and_out_size(
     metrics: Arc<Metrics>,
     code: Option<WsServiceError>,
     procedure: Procedure,

--- a/src/ws/metrics.rs
+++ b/src/ws/metrics.rs
@@ -187,7 +187,8 @@ pub async fn decrement_connected_clients(metrics: Arc<Metrics>) {
     metrics.connected_clients_total_collector.dec();
 }
 
-/// Records updates sent on subscription. This increments the counter of updates sent
+/// Records updates sent on subscription.
+/// This increments the counter of updates sent
 /// on subscription based on the event type.
 pub async fn record_friendship_event_updates_sent(metrics: Arc<Metrics>, event: FriendshipEvent) {
     metrics
@@ -227,7 +228,8 @@ async fn record_out_procedure_call_size(
         .observe(size as f64);
 }
 
-/// Records the duration of a procedure call. This adds the duration of the procedure call to the
+/// Records the duration of a procedure call.
+/// This adds the duration of the procedure call to the
 /// histogram for the specified procedure and response code.
 async fn record_request_procedure_call_duration(
     metrics: Arc<Metrics>,
@@ -243,12 +245,13 @@ async fn record_request_procedure_call_duration(
         .observe(duration);
 }
 
-/// Records a procedure call, its duration and its response size.
-pub async fn record_procedure_call_and_duration(
+/// Records a procedure call, its duration and its outgoing payload size.
+pub async fn record_procedure_call_and_duration_and_size(
     metrics: Arc<Metrics>,
     code: Option<WsServiceError>,
     procedure: Procedure,
     start_time: Instant,
+    size: usize,
 ) {
     record_procedure_call(metrics.clone(), code.clone(), procedure.clone()).await;
     record_request_procedure_call_duration(
@@ -258,7 +261,7 @@ pub async fn record_procedure_call_and_duration(
         start_time,
     )
     .await;
-    // TODO Juli: call record_out_procedure_call_size
+    record_out_procedure_call_size(metrics, code, procedure, size).await;
 }
 
 /// Calculates the size of the encoded message in bytes.

--- a/src/ws/metrics.rs
+++ b/src/ws/metrics.rs
@@ -174,7 +174,7 @@ pub async fn decrement_connected_clients(metrics: Arc<Metrics>) {
 
 /// Records updates sent on subscription. This increments the counter of updates sent
 /// on subscription based on the event type.
-pub async fn record_updates_sent(metrics: Arc<Metrics>, event: FriendshipEvent) {
+pub async fn record_friendship_event_updates_sent(metrics: Arc<Metrics>, event: FriendshipEvent) {
     metrics
         .updates_sent_on_subscription_total_collector
         .with_label_values(&[event.as_str()])

--- a/src/ws/service/friendships_service.rs
+++ b/src/ws/service/friendships_service.rs
@@ -506,6 +506,7 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
                             );
                     }
                     None => {
+                        log::warn!("This code should be unreachable");
                         // This should never happen
                         context
                             .server_context

--- a/src/ws/service/friendships_service.rs
+++ b/src/ws/service/friendships_service.rs
@@ -71,7 +71,9 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
     ) -> Result<ServerStreamResponse<UsersResponse>, RPCFriendshipsServiceError> {
         let start_time = Instant::now();
         let metrics = context.server_context.metrics.clone();
-        metrics.record_in_procedure_call_size(Procedure::GetFriends, &request);
+        metrics
+            .clone()
+            .record_in_procedure_call_size(Procedure::GetFriends, &request);
 
         let request_user_id = get_user_id_from_request(
             &request,
@@ -137,6 +139,7 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
                         };
                         return Ok(friendships_generator);
                     };
+                let metrics_clone = metrics.clone();
                 tokio::spawn(async move {
                     let mut users = Users::default();
 
@@ -146,11 +149,15 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
                     while let Some(friendship) = friendship.next().await {
                         users.users.push(build_user(friendship, user_id.clone()));
                         if users.users.len() == friends_stream_page_size {
-                            let result = friendships_yielder
-                                .r#yield(UsersResponse::from_response(
-                                    users_response::Response::Users(users.clone()),
-                                ))
-                                .await;
+                            let response = UsersResponse::from_response(
+                                users_response::Response::Users(users.clone()),
+                            );
+                            metrics_clone.record_out_procedure_call_size(
+                                None,
+                                Procedure::GetFriends,
+                                response.encoded_len(),
+                            );
+                            let result = friendships_yielder.r#yield(response).await;
                             if let Err(err) = result {
                                 log::error!("[RPC] There was an error yielding the response to the friendships generator: {:?}", err);
                                 break;
@@ -161,10 +168,9 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
                     if !users.users.is_empty() {
                         let response =
                             UsersResponse::from_response(users_response::Response::Users(users));
-                        metrics.record_procedure_call_and_duration_and_out_size(
+                        metrics_clone.record_out_procedure_call_size(
                             None,
                             Procedure::GetFriends,
-                            start_time,
                             response.encoded_len(),
                         );
                         let result = friendships_yielder.r#yield(response).await;
@@ -173,6 +179,9 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
                         };
                     }
                 });
+
+                metrics.record_procedure_call_and_duration(None, Procedure::GetFriends, start_time);
+
                 log::info!(
                     "[RPC] Returning generator for all friends for user {}",
                     social_id
@@ -471,6 +480,12 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
                 };
             }
             Ok(user_id) => {
+                metrics.record_procedure_call_and_duration(
+                    None,
+                    Procedure::SubscribeFriendshipEventsUpdates,
+                    start_time,
+                );
+
                 // Attach transport_id to the context by transport
                 context
                     .server_context
@@ -494,6 +509,7 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
                     .insert(Address(user_id.social_id), friendships_yielder.clone());
             }
         }
+
         Ok(friendships_generator)
     }
 }
@@ -504,7 +520,7 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
 /// user id from the token and returns it as a `Result<UserId>`. If no
 /// authentication token was provided, returns a `Err(CommonError::Unauthorized)`
 /// error.
-pub async fn get_user_id_from_request(
+async fn get_user_id_from_request(
     request: &Payload,
     synapse: SynapseComponent,
     users_cache: Arc<Mutex<UsersCacheComponent>>,

--- a/src/ws/service/friendships_service.rs
+++ b/src/ws/service/friendships_service.rs
@@ -29,7 +29,7 @@ use crate::{
         app::{SocialContext, SocialTransportContext},
         metrics::{
             record_friendship_event_updates_sent, record_in_procedure_call_size,
-            record_procedure_call_and_duration_and_size, Procedure,
+            record_procedure_call_and_duration_and_out_size, Procedure,
         },
     },
 };
@@ -88,7 +88,7 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
         let Some(repos) = context.server_context.db.db_repos.clone() else {
             log::error!("[RPC] Get friends > Db repositories > `repos` is None.");
             let error = InternalServerError{ message: "An error occurred while getting the friendships".to_owned() };
-            record_procedure_call_and_duration_and_size(metrics.clone(), Some(error.clone().into()), Procedure::GetFriends, start_time, error.encoded_len()).await;
+            record_procedure_call_and_duration_and_out_size(metrics.clone(), Some(error.clone().into()), Procedure::GetFriends, start_time, error.encoded_len()).await;
 
             let result = friendships_yielder
             .r#yield(UsersResponse::from_response(users_response::Response::InternalServerError(
@@ -103,7 +103,7 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
         match request_user_id {
             Err(err) => {
                 let error_response: UsersResponse = err.clone().into();
-                record_procedure_call_and_duration_and_size(
+                record_procedure_call_and_duration_and_out_size(
                     metrics.clone(),
                     Some(err.clone().into()),
                     Procedure::GetFriends,
@@ -131,7 +131,7 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
                             "[RPC] Get friends > Get user friends stream > Error: There was an error accessing to the friendships repository."
                         );
                         let error = InternalServerError{ message: "An error occurred while sending the response to the stream".to_owned() };
-                        record_procedure_call_and_duration_and_size(metrics, Some(error.clone().into()), Procedure::GetFriends, start_time, error.encoded_len()).await;
+                        record_procedure_call_and_duration_and_out_size(metrics, Some(error.clone().into()), Procedure::GetFriends, start_time, error.encoded_len()).await;
 
                         let result = friendships_yielder
                             .r#yield(UsersResponse::from_response(users_response::Response::InternalServerError(
@@ -166,7 +166,7 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
                     if !users.users.is_empty() {
                         let response =
                             UsersResponse::from_response(users_response::Response::Users(users));
-                        record_procedure_call_and_duration_and_size(
+                        record_procedure_call_and_duration_and_out_size(
                             metrics,
                             None,
                             Procedure::GetFriends,
@@ -209,7 +209,7 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
         match request_user_id {
             Err(err) => {
                 let error_response: RequestEventsResponse = err.clone().into();
-                record_procedure_call_and_duration_and_size(
+                record_procedure_call_and_duration_and_out_size(
                     metrics,
                     Some(err.clone().into()),
                     Procedure::GetRequestEvents,
@@ -226,7 +226,7 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
                 let Some(repos) = context.server_context.db.db_repos.clone() else {
                     log::error!("[RPC] Get request events > Db repositories > `repos` is None.");
                     let error = InternalServerError { message: "".to_owned() };
-                    record_procedure_call_and_duration_and_size(metrics, Some(error.clone().into()), Procedure::GetRequestEvents, start_time, error.encoded_len()).await;
+                    record_procedure_call_and_duration_and_out_size(metrics, Some(error.clone().into()), Procedure::GetRequestEvents, start_time, error.encoded_len()).await;
 
                     return Ok(RequestEventsResponse::from_response(
                         request_events_response::Response::InternalServerError(error)));
@@ -245,7 +245,7 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
                         let error = InternalServerError {
                             message: "".to_owned(),
                         };
-                        record_procedure_call_and_duration_and_size(
+                        record_procedure_call_and_duration_and_out_size(
                             metrics,
                             Some(error.clone().into()),
                             Procedure::GetRequestEvents,
@@ -263,7 +263,7 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
                             requests,
                             user_id.social_id,
                         );
-                        record_procedure_call_and_duration_and_size(
+                        record_procedure_call_and_duration_and_out_size(
                             metrics,
                             None,
                             Procedure::GetRequestEvents,
@@ -291,7 +291,7 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
 
         let Some(auth_token) = request.clone().auth_token.take() else {
             let error = UnauthorizedError{ message: "`auth_token` was not provided".to_owned() };
-            record_procedure_call_and_duration_and_size(metrics, Some(error.clone().into()), Procedure::UpdateFriendshipEvent, start_time, error.encoded_len()).await;
+            record_procedure_call_and_duration_and_out_size(metrics, Some(error.clone().into()), Procedure::UpdateFriendshipEvent, start_time, error.encoded_len()).await;
 
             return Ok(UpdateFriendshipResponse::from_response(
                 update_friendship_response::Response::UnauthorizedError(
@@ -311,7 +311,7 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
         match request_user_id {
             Err(err) => {
                 let error_response: UpdateFriendshipResponse = err.clone().into();
-                record_procedure_call_and_duration_and_size(
+                record_procedure_call_and_duration_and_out_size(
                     metrics,
                     Some(err.clone().into()),
                     Procedure::UpdateFriendshipEvent,
@@ -327,7 +327,7 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
                 match event_payload {
                     Err(err) => {
                         let error_response: UpdateFriendshipResponse = err.clone().into();
-                        record_procedure_call_and_duration_and_size(
+                        record_procedure_call_and_duration_and_out_size(
                             metrics,
                             Some(err.clone().into()),
                             Procedure::UpdateFriendshipEvent,
@@ -343,7 +343,7 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
                         match token {
                             Err(err) => {
                                 let error_response: UpdateFriendshipResponse = err.clone().into();
-                                record_procedure_call_and_duration_and_size(
+                                record_procedure_call_and_duration_and_out_size(
                                     metrics,
                                     Some(err.clone().into()),
                                     Procedure::UpdateFriendshipEvent,
@@ -367,7 +367,7 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
                                     Err(err) => {
                                         let error_response: UpdateFriendshipResponse =
                                             err.clone().into();
-                                        record_procedure_call_and_duration_and_size(
+                                        record_procedure_call_and_duration_and_out_size(
                                             metrics,
                                             Some(err.clone().into()),
                                             Procedure::UpdateFriendshipEvent,
@@ -394,7 +394,7 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
                                             Err(err) => {
                                                 let error_response: UpdateFriendshipResponse =
                                                     err.clone().into();
-                                                record_procedure_call_and_duration_and_size(
+                                                record_procedure_call_and_duration_and_out_size(
                                                     metrics,
                                                     Some(err.clone().into()),
                                                     Procedure::UpdateFriendshipEvent,
@@ -436,7 +436,7 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
                                                         }
                                                     });
                                                 };
-                                                record_procedure_call_and_duration_and_size(
+                                                record_procedure_call_and_duration_and_out_size(
                                                     metrics,
                                                     None,
                                                     Procedure::UpdateFriendshipEvent,
@@ -491,7 +491,7 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
         match request_user_id {
             Err(err) => {
                 let error_response: SubscribeFriendshipEventsUpdatesResponse = err.clone().into();
-                record_procedure_call_and_duration_and_size(
+                record_procedure_call_and_duration_and_out_size(
                     metrics.clone(),
                     Some(err.clone().into()),
                     Procedure::SubscribeFriendshipEventsUpdates,

--- a/src/ws/service/friendships_service.rs
+++ b/src/ws/service/friendships_service.rs
@@ -532,15 +532,6 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
                     .write()
                     .await
                     .insert(Address(user_id.social_id), friendships_yielder.clone());
-
-                record_procedure_call_and_duration_and_size(
-                    metrics,
-                    None,
-                    Procedure::SubscribeFriendshipEventsUpdates,
-                    start_time,
-                    0,
-                )
-                .await;
             }
         }
         Ok(friendships_generator)

--- a/src/ws/service/friendships_service.rs
+++ b/src/ws/service/friendships_service.rs
@@ -481,6 +481,7 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
                         context.transport_id,
                         SocialTransportContext {
                             address: Address(user_id.social_id.to_string()),
+                            connection_ts: Instant::now(),
                         },
                     );
 

--- a/src/ws/service/friendships_service.rs
+++ b/src/ws/service/friendships_service.rs
@@ -1,6 +1,6 @@
 use std::{
     sync::Arc,
-    time::{SystemTime, UNIX_EPOCH},
+    time::{Instant, SystemTime, UNIX_EPOCH},
 };
 
 use dcl_rpc::{
@@ -27,7 +27,8 @@ use crate::{
     ws::{
         app::{SocialContext, SocialTransportContext},
         metrics::{
-            record_procedure_call, record_procedure_call_size, record_updates_sent, Procedure,
+            record_procedure_call_and_duration, record_procedure_call_size, record_updates_sent,
+            Procedure,
         },
     },
 };
@@ -70,8 +71,8 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
         request: Payload,
         context: ProcedureContext<SocialContext>,
     ) -> Result<ServerStreamResponse<UsersResponse>, RPCFriendshipsServiceError> {
+        let start = Instant::now();
         let metrics = context.server_context.metrics.clone();
-
         record_procedure_call_size(metrics.clone(), Procedure::GetFriends, &request).await;
 
         let request_user_id = get_user_id_from_request(
@@ -85,12 +86,15 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
 
         let Some(repos) = context.server_context.db.db_repos.clone() else {
             log::error!("[RPC] Get friends > Db repositories > `repos` is None.");
+
             let error = InternalServerError{ message: "An error occurred while getting the friendships".to_owned() };
-            record_procedure_call(metrics.clone(), Some(error.clone().into()), Procedure::GetFriends).await;
+            record_procedure_call_and_duration(metrics.clone(), Some(error.clone().into()), Procedure::GetFriends, start).await;
+
             let result = friendships_yielder
             .r#yield(UsersResponse::from_response(users_response::Response::InternalServerError(
                 error)))
             .await;
+
             if let Err(err) = result {
                 log::error!("[RPC] There was an error yielding the error to the friendships generator: {:?}", err);
             };
@@ -99,12 +103,14 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
 
         match request_user_id {
             Err(err) => {
-                record_procedure_call(
+                record_procedure_call_and_duration(
                     metrics.clone(),
                     Some(err.clone().into()),
                     Procedure::GetFriends,
+                    start,
                 )
                 .await;
+
                 let result = friendships_yielder.r#yield(err.into()).await;
                 if let Err(err) = result {
                     log::error!(
@@ -125,7 +131,7 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
                             "[RPC] Get friends > Get user friends stream > Error: There was an error accessing to the friendships repository."
                         );
                         let error = InternalServerError{ message: "An error occurred while sending the response to the stream".to_owned() };
-                        record_procedure_call(metrics,Some(error.clone().into()), Procedure::GetFriends).await;
+                        record_procedure_call_and_duration(metrics, Some(error.clone().into()), Procedure::GetFriends, start).await;
                         let result = friendships_yielder
                             .r#yield(UsersResponse::from_response(users_response::Response::InternalServerError(
                                 error)))
@@ -173,7 +179,8 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
                 );
             }
         }
-        record_procedure_call(metrics, None, Procedure::GetFriends).await;
+        record_procedure_call_and_duration(metrics, None, Procedure::GetFriends, start).await;
+
         Ok(friendships_generator)
     }
 
@@ -183,8 +190,8 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
         request: Payload,
         context: ProcedureContext<SocialContext>,
     ) -> Result<RequestEventsResponse, RPCFriendshipsServiceError> {
+        let start = Instant::now();
         let metrics = context.server_context.metrics.clone();
-
         record_procedure_call_size(metrics.clone(), Procedure::GetRequestEvents, &request).await;
 
         let request_user_id = get_user_id_from_request(
@@ -196,12 +203,14 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
 
         match request_user_id {
             Err(err) => {
-                record_procedure_call(
-                    metrics.clone(),
+                record_procedure_call_and_duration(
+                    metrics,
                     Some(err.clone().into()),
                     Procedure::GetRequestEvents,
+                    start,
                 )
                 .await;
+
                 return Ok(err.into());
             }
             Ok(user_id) => {
@@ -211,7 +220,7 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
                 let Some(repos) = context.server_context.db.db_repos.clone() else {
                     log::error!("[RPC] Get request events > Db repositories > `repos` is None.");
                     let error = InternalServerError { message: "".to_owned() };
-                    record_procedure_call( metrics,Some(error.clone().into()), Procedure::GetRequestEvents).await;
+                    record_procedure_call_and_duration(metrics, Some(error.clone().into()), Procedure::GetRequestEvents, start).await;
 
                     return Ok(RequestEventsResponse::from_response(
                         request_events_response::Response::InternalServerError(error)));
@@ -230,10 +239,11 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
                         let error = InternalServerError {
                             message: "".to_owned(),
                         };
-                        record_procedure_call(
+                        record_procedure_call_and_duration(
                             metrics,
                             Some(error.clone().into()),
                             Procedure::GetRequestEvents,
+                            start,
                         )
                         .await;
 
@@ -243,7 +253,14 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
                     }
                     Ok(requests) => {
                         log::info!("Returning requests events for user {}", social_id);
-                        record_procedure_call(metrics, None, Procedure::GetRequestEvents).await;
+                        record_procedure_call_and_duration(
+                            metrics,
+                            None,
+                            Procedure::GetRequestEvents,
+                            start,
+                        )
+                        .await;
+
                         Ok(friendship_requests_as_request_events_response(
                             requests,
                             user_id.social_id,
@@ -260,14 +277,14 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
         request: UpdateFriendshipPayload,
         context: ProcedureContext<SocialContext>,
     ) -> Result<UpdateFriendshipResponse, RPCFriendshipsServiceError> {
+        let start = Instant::now();
         let metrics = context.server_context.metrics.clone();
-
         record_procedure_call_size(metrics.clone(), Procedure::UpdateFriendshipEvent, &request)
             .await;
 
         let Some(auth_token) = request.clone().auth_token.take() else {
             let error = UnauthorizedError{ message: "`auth_token` was not provided".to_owned() };
-            record_procedure_call( metrics,Some(error.clone().into()), Procedure::UpdateFriendshipEvent).await;
+            record_procedure_call_and_duration(metrics, Some(error.clone().into()), Procedure::UpdateFriendshipEvent, start).await;
 
             return Ok(UpdateFriendshipResponse::from_response(
                 update_friendship_response::Response::UnauthorizedError(
@@ -286,12 +303,14 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
 
         match request_user_id {
             Err(err) => {
-                record_procedure_call(
+                record_procedure_call_and_duration(
                     metrics,
                     Some(err.clone().into()),
                     Procedure::UpdateFriendshipEvent,
+                    start,
                 )
                 .await;
+
                 return Ok(err.into());
             }
             Ok(user_id) => {
@@ -299,12 +318,14 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
 
                 match event_payload {
                     Err(err) => {
-                        record_procedure_call(
+                        record_procedure_call_and_duration(
                             metrics,
                             Some(err.clone().into()),
                             Procedure::UpdateFriendshipEvent,
+                            start,
                         )
                         .await;
+
                         return Ok(err.into());
                     }
                     Ok(event_payload) => {
@@ -312,12 +333,14 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
 
                         match token {
                             Err(err) => {
-                                record_procedure_call(
+                                record_procedure_call_and_duration(
                                     metrics,
                                     Some(err.clone().into()),
                                     Procedure::UpdateFriendshipEvent,
+                                    start,
                                 )
                                 .await;
+
                                 return Ok(err.into());
                             }
                             Ok(token) => {
@@ -332,12 +355,14 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
 
                                 match friendship_update_response {
                                     Err(err) => {
-                                        record_procedure_call(
+                                        record_procedure_call_and_duration(
                                             metrics,
                                             Some(err.clone().into()),
                                             Procedure::UpdateFriendshipEvent,
+                                            start,
                                         )
                                         .await;
+
                                         return Ok(err.into());
                                     }
                                     Ok(friendship_update_response) => {
@@ -355,12 +380,14 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
                                         let metrics_clone = Arc::clone(&metrics);
                                         match update_response {
                                             Err(err) => {
-                                                record_procedure_call(
+                                                record_procedure_call_and_duration(
                                                     metrics,
                                                     Some(err.clone().into()),
                                                     Procedure::UpdateFriendshipEvent,
+                                                    start,
                                                 )
                                                 .await;
+
                                                 return Ok(err.into());
                                             }
                                             Ok(update_response) => {
@@ -395,12 +422,14 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
                                                         }
                                                     });
                                                 };
-                                                record_procedure_call(
+                                                record_procedure_call_and_duration(
                                                     metrics,
                                                     None,
                                                     Procedure::UpdateFriendshipEvent,
+                                                    start,
                                                 )
                                                 .await;
+
                                                 Ok(update_response)
                                             }
                                         }
@@ -426,8 +455,8 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
         ServerStreamResponse<SubscribeFriendshipEventsUpdatesResponse>,
         RPCFriendshipsServiceError,
     > {
+        let start = Instant::now();
         let metrics = context.server_context.metrics.clone();
-
         record_procedure_call_size(
             metrics.clone(),
             Procedure::SubscribeFriendshipEventsUpdates,
@@ -446,10 +475,11 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
 
         match request_user_id {
             Err(err) => {
-                record_procedure_call(
+                record_procedure_call_and_duration(
                     metrics.clone(),
                     Some(err.clone().into()),
                     Procedure::SubscribeFriendshipEventsUpdates,
+                    start,
                 )
                 .await;
 
@@ -481,7 +511,13 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
                     .insert(Address(user_id.social_id), friendships_yielder.clone());
             }
         }
-        record_procedure_call(metrics, None, Procedure::SubscribeFriendshipEventsUpdates).await;
+        record_procedure_call_and_duration(
+            metrics,
+            None,
+            Procedure::SubscribeFriendshipEventsUpdates,
+            start,
+        )
+        .await;
         Ok(friendships_generator)
     }
 }

--- a/src/ws/service/friendships_service.rs
+++ b/src/ws/service/friendships_service.rs
@@ -97,7 +97,6 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
             if let Err(err) = result {
                 log::error!("[RPC] There was an error yielding the error to the friendships generator: {:?}", err);
             };
-
             return Ok(friendships_generator);
         };
 
@@ -112,7 +111,6 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
                     error_response.encoded_len(),
                 )
                 .await;
-
                 let result = friendships_yielder.r#yield(error_response).await;
                 if let Err(err) = result {
                     log::error!(
@@ -142,7 +140,6 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
                         if let Err(err) = result {
                             log::error!("[RPC] There was an error yielding the error to the friendships generator: {:?}", err);
                         };
-
                         return Ok(friendships_generator);
                     };
                 tokio::spawn(async move {
@@ -256,14 +253,12 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
                             error.encoded_len(),
                         )
                         .await;
-
                         Ok(RequestEventsResponse::from_response(
                             request_events_response::Response::InternalServerError(error),
                         ))
                     }
                     Ok(requests) => {
                         log::info!("Returning requests events for user {}", social_id);
-
                         let response = friendship_requests_as_request_events_response(
                             requests,
                             user_id.social_id,
@@ -276,7 +271,6 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
                             response.encoded_len(),
                         )
                         .await;
-
                         Ok(response)
                     }
                 }
@@ -505,7 +499,6 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
                     error_response.encoded_len(),
                 )
                 .await;
-
                 let result = friendships_yielder.r#yield(error_response).await;
                 if let Err(err) = result {
                     log::error!("[RPC] There was an error yielding the error to the subscribe friendships generator: {:?}", err);

--- a/src/ws/service/friendships_service.rs
+++ b/src/ws/service/friendships_service.rs
@@ -27,10 +27,7 @@ use crate::{
     },
     ws::{
         app::{SocialContext, SocialTransportContext},
-        metrics::{
-            record_friendship_event_updates_sent, record_in_procedure_call_size,
-            record_procedure_call_and_duration_and_out_size, Procedure,
-        },
+        metrics::Procedure,
     },
 };
 
@@ -74,7 +71,7 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
     ) -> Result<ServerStreamResponse<UsersResponse>, RPCFriendshipsServiceError> {
         let start_time = Instant::now();
         let metrics = context.server_context.metrics.clone();
-        record_in_procedure_call_size(metrics.clone(), Procedure::GetFriends, &request).await;
+        metrics.record_in_procedure_call_size(Procedure::GetFriends, &request);
 
         let request_user_id = get_user_id_from_request(
             &request,
@@ -88,7 +85,7 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
         let Some(repos) = context.server_context.db.db_repos.clone() else {
             log::error!("[RPC] Get friends > Db repositories > `repos` is None.");
             let error = InternalServerError{ message: "An error occurred while getting the friendships".to_owned() };
-            record_procedure_call_and_duration_and_out_size(metrics.clone(), Some(error.clone().into()), Procedure::GetFriends, start_time, error.encoded_len()).await;
+            metrics.record_procedure_call_and_duration_and_out_size( Some(error.clone().into()), Procedure::GetFriends, start_time, error.encoded_len());
 
             let result = friendships_yielder
             .r#yield(UsersResponse::from_response(users_response::Response::InternalServerError(
@@ -103,14 +100,12 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
         match request_user_id {
             Err(err) => {
                 let error_response: UsersResponse = err.clone().into();
-                record_procedure_call_and_duration_and_out_size(
-                    metrics.clone(),
+                metrics.record_procedure_call_and_duration_and_out_size(
                     Some(err.clone().into()),
                     Procedure::GetFriends,
                     start_time,
                     error_response.encoded_len(),
-                )
-                .await;
+                );
                 let result = friendships_yielder.r#yield(error_response).await;
                 if let Err(err) = result {
                     log::error!(
@@ -131,7 +126,7 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
                             "[RPC] Get friends > Get user friends stream > Error: There was an error accessing to the friendships repository."
                         );
                         let error = InternalServerError{ message: "An error occurred while sending the response to the stream".to_owned() };
-                        record_procedure_call_and_duration_and_out_size(metrics, Some(error.clone().into()), Procedure::GetFriends, start_time, error.encoded_len()).await;
+                        metrics.record_procedure_call_and_duration_and_out_size(Some(error.clone().into()), Procedure::GetFriends, start_time, error.encoded_len());
 
                         let result = friendships_yielder
                             .r#yield(UsersResponse::from_response(users_response::Response::InternalServerError(
@@ -166,14 +161,12 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
                     if !users.users.is_empty() {
                         let response =
                             UsersResponse::from_response(users_response::Response::Users(users));
-                        record_procedure_call_and_duration_and_out_size(
-                            metrics,
+                        metrics.record_procedure_call_and_duration_and_out_size(
                             None,
                             Procedure::GetFriends,
                             start_time,
                             response.encoded_len(),
-                        )
-                        .await;
+                        );
                         let result = friendships_yielder.r#yield(response).await;
                         if let Err(err) = result {
                             log::error!("[RPC] There was an error yielding the response to the friendships generator: {:?}", err);
@@ -197,7 +190,7 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
     ) -> Result<RequestEventsResponse, RPCFriendshipsServiceError> {
         let start_time = Instant::now();
         let metrics = context.server_context.metrics.clone();
-        record_in_procedure_call_size(metrics.clone(), Procedure::GetRequestEvents, &request).await;
+        metrics.record_in_procedure_call_size(Procedure::GetRequestEvents, &request);
 
         let request_user_id = get_user_id_from_request(
             &request,
@@ -209,14 +202,12 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
         match request_user_id {
             Err(err) => {
                 let error_response: RequestEventsResponse = err.clone().into();
-                record_procedure_call_and_duration_and_out_size(
-                    metrics,
-                    Some(err.clone().into()),
+                metrics.record_procedure_call_and_duration_and_out_size(
+                    Some(err.into()),
                     Procedure::GetRequestEvents,
                     start_time,
                     error_response.encoded_len(),
-                )
-                .await;
+                );
                 return Ok(error_response);
             }
             Ok(user_id) => {
@@ -226,7 +217,7 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
                 let Some(repos) = context.server_context.db.db_repos.clone() else {
                     log::error!("[RPC] Get request events > Db repositories > `repos` is None.");
                     let error = InternalServerError { message: "".to_owned() };
-                    record_procedure_call_and_duration_and_out_size(metrics, Some(error.clone().into()), Procedure::GetRequestEvents, start_time, error.encoded_len()).await;
+                    metrics.record_procedure_call_and_duration_and_out_size(Some(error.clone().into()), Procedure::GetRequestEvents, start_time, error.encoded_len());
 
                     return Ok(RequestEventsResponse::from_response(
                         request_events_response::Response::InternalServerError(error)));
@@ -245,14 +236,12 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
                         let error = InternalServerError {
                             message: "".to_owned(),
                         };
-                        record_procedure_call_and_duration_and_out_size(
-                            metrics,
+                        metrics.record_procedure_call_and_duration_and_out_size(
                             Some(error.clone().into()),
                             Procedure::GetRequestEvents,
                             start_time,
                             error.encoded_len(),
-                        )
-                        .await;
+                        );
                         Ok(RequestEventsResponse::from_response(
                             request_events_response::Response::InternalServerError(error),
                         ))
@@ -263,14 +252,12 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
                             requests,
                             user_id.social_id,
                         );
-                        record_procedure_call_and_duration_and_out_size(
-                            metrics,
+                        metrics.record_procedure_call_and_duration_and_out_size(
                             None,
                             Procedure::GetRequestEvents,
                             start_time,
                             response.encoded_len(),
-                        )
-                        .await;
+                        );
                         Ok(response)
                     }
                 }
@@ -286,12 +273,11 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
     ) -> Result<UpdateFriendshipResponse, RPCFriendshipsServiceError> {
         let start_time = Instant::now();
         let metrics = context.server_context.metrics.clone();
-        record_in_procedure_call_size(metrics.clone(), Procedure::UpdateFriendshipEvent, &request)
-            .await;
+        metrics.record_in_procedure_call_size(Procedure::UpdateFriendshipEvent, &request);
 
         let Some(auth_token) = request.clone().auth_token.take() else {
             let error = UnauthorizedError{ message: "`auth_token` was not provided".to_owned() };
-            record_procedure_call_and_duration_and_out_size(metrics, Some(error.clone().into()), Procedure::UpdateFriendshipEvent, start_time, error.encoded_len()).await;
+            metrics.record_procedure_call_and_duration_and_out_size(Some(error.clone().into()), Procedure::UpdateFriendshipEvent, start_time, error.encoded_len());
 
             return Ok(UpdateFriendshipResponse::from_response(
                 update_friendship_response::Response::UnauthorizedError(
@@ -311,14 +297,12 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
         match request_user_id {
             Err(err) => {
                 let error_response: UpdateFriendshipResponse = err.clone().into();
-                record_procedure_call_and_duration_and_out_size(
-                    metrics,
-                    Some(err.clone().into()),
+                metrics.record_procedure_call_and_duration_and_out_size(
+                    Some(err.into()),
                     Procedure::UpdateFriendshipEvent,
                     start_time,
                     error_response.encoded_len(),
-                )
-                .await;
+                );
                 return Ok(error_response);
             }
             Ok(user_id) => {
@@ -327,14 +311,12 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
                 match event_payload {
                     Err(err) => {
                         let error_response: UpdateFriendshipResponse = err.clone().into();
-                        record_procedure_call_and_duration_and_out_size(
-                            metrics,
-                            Some(err.clone().into()),
+                        metrics.record_procedure_call_and_duration_and_out_size(
+                            Some(err.into()),
                             Procedure::UpdateFriendshipEvent,
                             start_time,
                             error_response.encoded_len(),
-                        )
-                        .await;
+                        );
                         return Ok(error_response);
                     }
                     Ok(event_payload) => {
@@ -343,14 +325,12 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
                         match token {
                             Err(err) => {
                                 let error_response: UpdateFriendshipResponse = err.clone().into();
-                                record_procedure_call_and_duration_and_out_size(
-                                    metrics,
-                                    Some(err.clone().into()),
+                                metrics.record_procedure_call_and_duration_and_out_size(
+                                    Some(err.into()),
                                     Procedure::UpdateFriendshipEvent,
                                     start_time,
                                     error_response.encoded_len(),
-                                )
-                                .await;
+                                );
                                 return Ok(error_response);
                             }
                             Ok(token) => {
@@ -367,14 +347,12 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
                                     Err(err) => {
                                         let error_response: UpdateFriendshipResponse =
                                             err.clone().into();
-                                        record_procedure_call_and_duration_and_out_size(
-                                            metrics,
-                                            Some(err.clone().into()),
+                                        metrics.record_procedure_call_and_duration_and_out_size(
+                                            Some(err.into()),
                                             Procedure::UpdateFriendshipEvent,
                                             start_time,
                                             error_response.encoded_len(),
-                                        )
-                                        .await;
+                                        );
                                         return Ok(error_response);
                                     }
                                     Ok(friendship_update_response) => {
@@ -394,14 +372,12 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
                                             Err(err) => {
                                                 let error_response: UpdateFriendshipResponse =
                                                     err.clone().into();
-                                                record_procedure_call_and_duration_and_out_size(
-                                                    metrics,
-                                                    Some(err.clone().into()),
+                                                metrics.record_procedure_call_and_duration_and_out_size(
+                                                    Some(err.into()),
                                                     Procedure::UpdateFriendshipEvent,
                                                     start_time,
                                                     error_response.encoded_len(),
-                                                )
-                                                .await;
+                                                );
                                                 return Ok(error_response);
                                             }
                                             Ok(update_response) => {
@@ -425,25 +401,21 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
                                                                     event,
                                                                 )
                                                             {
-                                                                record_friendship_event_updates_sent(
-                                                                    metrics_clone,
+                                                              metrics_clone.record_friendship_event_updates_sent(
                                                                     event,
-                                                                )
-                                                                .await;
+                                                                );
                                                             }
                                                         } else {
                                                             log::error!("[RPC] There was an error parsing from friendship payload to event")
                                                         }
                                                     });
                                                 };
-                                                record_procedure_call_and_duration_and_out_size(
-                                                    metrics,
+                                                metrics.record_procedure_call_and_duration_and_out_size(
                                                     None,
                                                     Procedure::UpdateFriendshipEvent,
                                                     start_time,
                                                     update_response.encoded_len(),
-                                                )
-                                                .await;
+                                                );
 
                                                 Ok(update_response)
                                             }
@@ -472,12 +444,8 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
     > {
         let start_time = Instant::now();
         let metrics = context.server_context.metrics.clone();
-        record_in_procedure_call_size(
-            metrics.clone(),
-            Procedure::SubscribeFriendshipEventsUpdates,
-            &request,
-        )
-        .await;
+        metrics
+            .record_in_procedure_call_size(Procedure::SubscribeFriendshipEventsUpdates, &request);
 
         let request_user_id = get_user_id_from_request(
             &request,
@@ -491,14 +459,12 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
         match request_user_id {
             Err(err) => {
                 let error_response: SubscribeFriendshipEventsUpdatesResponse = err.clone().into();
-                record_procedure_call_and_duration_and_out_size(
-                    metrics.clone(),
+                metrics.record_procedure_call_and_duration_and_out_size(
                     Some(err.clone().into()),
                     Procedure::SubscribeFriendshipEventsUpdates,
                     start_time,
                     error_response.encoded_len(),
-                )
-                .await;
+                );
                 let result = friendships_yielder.r#yield(error_response).await;
                 if let Err(err) = result {
                     log::error!("[RPC] There was an error yielding the error to the subscribe friendships generator: {:?}", err);

--- a/src/ws/service/friendships_service.rs
+++ b/src/ws/service/friendships_service.rs
@@ -27,8 +27,8 @@ use crate::{
     ws::{
         app::{SocialContext, SocialTransportContext},
         metrics::{
-            record_procedure_call_and_duration, record_procedure_call_size, record_updates_sent,
-            Procedure,
+            record_friendship_event_updates_sent, record_procedure_call_and_duration,
+            record_procedure_call_size, Procedure,
         },
     },
 };
@@ -411,7 +411,7 @@ impl FriendshipsServiceServer<SocialContext, RPCFriendshipsServiceError> for MyF
                                                                     event,
                                                                 )
                                                             {
-                                                                record_updates_sent(
+                                                                record_friendship_event_updates_sent(
                                                                     metrics_clone,
                                                                     event,
                                                                 )

--- a/src/ws/service/mapper/error.rs
+++ b/src/ws/service/mapper/error.rs
@@ -8,6 +8,7 @@ use crate::{
     },
 };
 
+#[derive(Clone)]
 pub enum WsServiceError {
     Unauthorized(UnauthorizedError),
     InternalServer(InternalServerError),

--- a/src/ws/service/mapper/event.rs
+++ b/src/ws/service/mapper/event.rs
@@ -144,6 +144,7 @@ pub fn update_request_as_event_payload(
     Ok(event_payload)
 }
 
+///
 pub fn event_response_as_update_response(
     request: UpdateFriendshipPayload,
     result: EventResponse,
@@ -232,6 +233,7 @@ pub fn event_response_as_update_response(
     Ok(update_response)
 }
 
+/// Maps a `FriendshipEventPayload` to an `Event` struct.
 pub fn update_friendship_payload_as_event(
     payload: FriendshipEventPayload,
     from: &str,
@@ -245,5 +247,18 @@ pub fn update_friendship_payload_as_event(
         })
     } else {
         Err(CommonError::Unknown("".to_owned()))
+    }
+}
+
+/// Maps a `FriendshipEventPayload` to an `FriendshipEvent` struct.
+pub fn parse_event_payload_to_friendship_event(
+    payload: FriendshipEventPayload,
+) -> Option<FriendshipEvent> {
+    match payload.body? {
+        friendship_event_payload::Body::Request(_) => Some(FriendshipEvent::REQUEST),
+        friendship_event_payload::Body::Accept(_) => Some(FriendshipEvent::ACCEPT),
+        friendship_event_payload::Body::Reject(_) => Some(FriendshipEvent::REJECT),
+        friendship_event_payload::Body::Delete(_) => Some(FriendshipEvent::DELETE),
+        friendship_event_payload::Body::Cancel(_) => Some(FriendshipEvent::CANCEL),
     }
 }


### PR DESCRIPTION
Add metric that counts the clients currently connected via Websocket

Closes #249 

```
# HELP dcl_social_service_rpc_connected_clients_total Social Service RPC Websocket Connected Clients
# TYPE dcl_social_service_rpc_connected_clients_total gauge
dcl_social_service_rpc_connected_clients_total 2
```

-----

Adds metrics that collects the procedures call incoming and outgoing payload size.

Closes #253 

```
# HELP dcl_social_service_rpc_out_procedure_call_size_bytes_histogram Social Service RPC Websocket Procedure Outgoing Payload Call Size
# TYPE dcl_social_service_rpc_out_procedure_call_size_bytes_histogram histogram
dcl_social_service_rpc_out_procedure_call_size_bytes_histogram_bucket{procedure="GetFriends",le="+Inf"} 71
dcl_social_service_rpc_out_procedure_call_size_bytes_histogram_sum{procedure="GetFriends"} 6390
dcl_social_service_rpc_out_procedure_call_size_bytes_histogram_count{procedure="GetFriends"} 71
```

```
# HELP dcl_social_service_rpc_in_procedure_call_size_bytes_histogram Social Service RPC Websocket Procedure Incoming Payload Call Size
# TYPE dcl_social_service_rpc_in_procedure_call_size_bytes_histogram histogram
dcl_social_service_rpc_in_procedure_call_size_bytes_histogram_bucket{procedure="GetFriends",le="+Inf"} 1
dcl_social_service_rpc_in_procedure_call_size_bytes_histogram_sum{procedure="GetFriends"} 90
dcl_social_service_rpc_in_procedure_call_size_bytes_histogram_count{procedure="GetFriends"} 1
```

-----

Adds metric that counts the updates sent on subscription by event type.

Closes #254 

```
# HELP dcl_social_service_rpc_updates_sent_on_subscription_total Social Service RPC Websocket Updates Sent On Subscription
# TYPE dcl_social_service_rpc_updates_sent_on_subscription_total counter
dcl_social_service_rpc_updates_sent_on_subscription_total{event="cancel"} 1
dcl_social_service_rpc_updates_sent_on_subscription_total{event="request"} 1
```

-----

Adds metric that collects the procedures call duration in seconds.

Closes #252 

```
# HELP dcl_social_service_rpc_procedure_call_duration_seconds_histogram Social Service RPC Websocket Procedure Call Duration in Seconds
# TYPE dcl_social_service_rpc_procedure_call_duration_seconds_histogram histogram
dcl_social_service_rpc_procedure_call_duration_seconds_histogram_bucket{code="OK",procedure="GetRequestEvents",le="0.01"} 0
dcl_social_service_rpc_procedure_call_duration_seconds_histogram_bucket{code="OK",procedure="GetRequestEvents",le="0.025"} 1
dcl_social_service_rpc_procedure_call_duration_seconds_histogram_sum{code="OK",procedure="GetRequestEvents"} 0.02198975
dcl_social_service_rpc_procedure_call_duration_seconds_histogram_count{code="OK",procedure="GetRequestEvents"} 1
```