### PR TITLE
feat: counter updates sent on subscription

### DIFF
--- a/src/domain/friendship_event.rs
+++ b/src/domain/friendship_event.rs
@@ -16,6 +16,18 @@ pub enum FriendshipEvent {
     DELETE, // Delete an existing friendship
 }
 
+impl FriendshipEvent {
+    pub fn as_str(&self) -> &'static str {
+        match *self {
+            FriendshipEvent::REQUEST => "request",
+            FriendshipEvent::CANCEL => "cancel",
+            FriendshipEvent::ACCEPT => "accept",
+            FriendshipEvent::REJECT => "reject",
+            FriendshipEvent::DELETE => "delete",
+        }
+    }
+}
+
 lazy_static::lazy_static! {
     static ref VALID_FRIENDSHIP_EVENT_TRANSITIONS: HashMap<FriendshipEvent, Vec<Option<FriendshipEvent>>> = {
         let mut m = HashMap::new();

--- a/src/ws/metrics.rs
+++ b/src/ws/metrics.rs
@@ -151,6 +151,11 @@ pub async fn register_metrics(metrics: Arc<Mutex<Metrics>>) {
         .register(Box::new(metrics.connected_clients_total_collector.clone()))
         .expect("Connection Total Collector metrics should be correct, so CONNECTED_CLIENTS_COLLECTOR can be registered successfully");
 
+    metrics
+        .registry
+        .register(Box::new(metrics.updates_sent_on_subscription_total_collector.clone()))
+            .expect("Updates Sent On Subscription Total Collector metrics should be correct, so UPDATES_SENT_ON_SUBSCRIPTION_TOTAL_COLLECTOR can be registered successfully");
+
     log::info!("[RPC] Registered Social Service RPC Websocket metrics");
 }
 

--- a/src/ws/metrics.rs
+++ b/src/ws/metrics.rs
@@ -5,12 +5,15 @@ use warp::{http::header::HeaderValue, reject::Reject, Rejection, Reply};
 
 use prometheus::{self, Encoder, IntCounterVec, IntGauge, Opts, Registry};
 
+use crate::domain::friendship_event::FriendshipEvent;
+
 use super::service::mapper::error::WsServiceError;
 
 #[derive(Clone)]
 pub struct Metrics {
     pub procedure_call_total_collector: IntCounterVec,
     pub connected_clients_total_collector: IntGauge,
+    pub updates_sent_on_subscription_total_collector: IntCounterVec,
     pub registry: Registry,
 }
 
@@ -20,26 +23,53 @@ impl Default for Metrics {
     }
 }
 
+const PROCEDURE_CALL_METRIC: (&str, &str) = (
+    "dcl_social_service_rpc_procedure_call_total",
+    "Social Service RPC Websocket Procedure Calls",
+);
+const CONNECTED_CLIENTS_METRIC: (&str, &str) = (
+    "dcl_social_service_rpc_connected_clients_total",
+    "Social Service RPC Websocket Connected Clients",
+);
+const UPDATES_SENT_METRIC: (&str, &str) = (
+    "dcl_social_service_rpc_updates_sent_on_subscription_total",
+    "Social Service RPC Websocket Updates Sent On Subscription",
+);
+
 impl Metrics {
     pub fn new() -> Self {
-        let opts = Opts::new(
-            "dcl_social_service_rpc_procedure_call_total",
-            "Social Service RPC Websocket Procedure Calls",
-        );
+        let procedure_call_total_collector =
+          Self::create_int_counter_vec(PROCEDURE_CALL_METRIC, &["code", "procedure"])
+          .expect("Metrics definition is correct, so dcl_social_service_rpc_procedure_call_total metric should be created successfully");
 
-        let procedure_call_total_collector = IntCounterVec::new(opts, &["code", "procedure"])
-            .expect("Metrics definition is correct, so dcl_social_service_rpc_procedure_call_total metric should be created successfully");
+        let connected_clients_total_collector =
+          Self::create_int_gauge(CONNECTED_CLIENTS_METRIC)
+          .expect("Metrics definition is correct, so dcl_social_service_rpc_connected_clients_total metric should be created successfully");
 
-        let connected_clients_total_collector = IntGauge::new("dcl_social_service_rpc_connected_clients_total", "Social Service RPC Websocket Connected Clients")
-            .expect("Metrics definition is correct, so dcl_social_service_rpc_connected_clients_total metric should be created successfully");
+        let updates_sent_on_subscription_total_collector =
+          Self::create_int_counter_vec(UPDATES_SENT_METRIC, &["event"])
+          .expect("Metrics definition is correct, so dcl_social_service_rpc_updates_sent_on_subscription_total metric should be created successfully");
 
         let registry = Registry::new();
 
         Metrics {
             procedure_call_total_collector,
             connected_clients_total_collector,
+            updates_sent_on_subscription_total_collector,
             registry,
         }
+    }
+
+    fn create_int_counter_vec(
+        metric: (&str, &str),
+        labels: &[&str],
+    ) -> Result<IntCounterVec, prometheus::Error> {
+        let opts = Opts::new(metric.0, metric.1);
+        IntCounterVec::new(opts, labels)
+    }
+
+    fn create_int_gauge(metric: (&str, &str)) -> Result<IntGauge, prometheus::Error> {
+        IntGauge::new(metric.0, metric.1)
     }
 }
 
@@ -96,6 +126,14 @@ pub async fn increment_connected_clients(metrics: Arc<Mutex<Metrics>>) {
 pub async fn decrement_connected_clients(metrics: Arc<Mutex<Metrics>>) {
     let metrics = metrics.lock().await;
     metrics.connected_clients_total_collector.dec();
+}
+
+pub async fn record_updates_sent(metrics: Arc<Mutex<Metrics>>, event: FriendshipEvent) {
+    let metrics = metrics.lock().await;
+    metrics
+        .updates_sent_on_subscription_total_collector
+        .with_label_values(&[event.as_str()])
+        .inc();
 }
 
 pub async fn register_metrics(metrics: Arc<Mutex<Metrics>>) {

--- a/src/ws/service/mapper/event.rs
+++ b/src/ws/service/mapper/event.rs
@@ -144,6 +144,7 @@ pub fn update_request_as_event_payload(
     Ok(event_payload)
 }
 
+///
 pub fn event_response_as_update_response(
     request: UpdateFriendshipPayload,
     result: EventResponse,
@@ -232,6 +233,7 @@ pub fn event_response_as_update_response(
     Ok(update_response)
 }
 
+/// Maps a `FriendshipEventPayload` to an `Event` struct.
 pub fn update_friendship_payload_as_event(
     payload: FriendshipEventPayload,
     from: &str,
@@ -245,5 +247,18 @@ pub fn update_friendship_payload_as_event(
         })
     } else {
         Err(CommonError::Unknown("".to_owned()))
+    }
+}
+
+/// Maps a `FriendshipEventPayload` to an `FriendshipEvent` struct.
+pub fn parse_event_payload_to_friendship_event(
+    payload: FriendshipEventPayload,
+) -> Option<FriendshipEvent> {
+    match payload.body? {
+        friendship_event_payload::Body::Request(_) => Some(FriendshipEvent::REQUEST),
+        friendship_event_payload::Body::Accept(_) => Some(FriendshipEvent::ACCEPT),
+        friendship_event_payload::Body::Reject(_) => Some(FriendshipEvent::REJECT),
+        friendship_event_payload::Body::Delete(_) => Some(FriendshipEvent::DELETE),
+        friendship_event_payload::Body::Cancel(_) => Some(FriendshipEvent::CANCEL),
     }
 }


### PR DESCRIPTION
Adds metric that counts the updates sent on subscription by event type.

```
# HELP dcl_social_service_rpc_updates_sent_on_subscription_total Social Service RPC Websocket Updates Sent On Subscription
# TYPE dcl_social_service_rpc_updates_sent_on_subscription_total counter
dcl_social_service_rpc_updates_sent_on_subscription_total{event="cancel"} 1
dcl_social_service_rpc_updates_sent_on_subscription_total{event="request"} 1
```