### PR TITLE
feat: Separate concerns in stream methods

### DIFF
--- a/src/ws/app.rs
+++ b/src/ws/app.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::Arc, time::Instant};
+use std::{collections::HashMap, sync::Arc};
 
 use dcl_rpc::{
     server::RpcServer,
@@ -246,10 +246,9 @@ async fn send_update_to_corresponding_generator(
     if let Some(response) = event_as_friendship_update_response(event_update.clone()) {
         let corresponding_user_id = Address(event_update.to.to_lowercase());
 
-        metrics.record_procedure_call_and_duration_and_out_size(
+        metrics.record_out_procedure_call_size(
             None,
             Procedure::SubscribeFriendshipEventsUpdates,
-            Instant::now(),
             response.encoded_len(),
         );
 

--- a/src/ws/metrics.rs
+++ b/src/ws/metrics.rs
@@ -179,7 +179,7 @@ impl Metrics {
     /// Records the size of the outgoing payload of a procedure call.
     /// This adds the size of the procedure call outgoing payload to the
     /// histogram for the specified procedure and response code.
-    fn record_out_procedure_call_size(
+    pub fn record_out_procedure_call_size(
         &self,
         code: Option<WsServiceError>,
         procedure: Procedure,
@@ -205,6 +205,17 @@ impl Metrics {
         self.procedure_call_duration_seconds_histogram_collector
             .with_label_values(&[code, procedure.as_str()])
             .observe(duration);
+    }
+
+    /// Records a procedure call, its duration but not the size, useful for stream responses
+    pub fn record_procedure_call_and_duration(
+        &self,
+        code: Option<WsServiceError>,
+        procedure: Procedure,
+        start_time: Instant,
+    ) {
+        self.record_procedure_call(code.clone(), procedure.clone());
+        self.record_request_procedure_call_duration(code.clone(), procedure.clone(), start_time);
     }
 
     /// Records a procedure call, its duration and its outgoing payload size.


### PR DESCRIPTION
In this PR I'm proposing to always count the requests and duration when returning streams, but then increasing the metric of out_size only when a response is yielded to the stream