### PR TITLE
Add join event to synapse room

### DIFF
--- a/src/api/routes/synapse/room_events.rs
+++ b/src/api/routes/synapse/room_events.rs
@@ -32,6 +32,11 @@ pub struct RoomEventResponse {
 }
 
 #[derive(Deserialize, Serialize)]
+pub struct RoomJoinResponse {
+    pub room_id: String,
+}
+
+#[derive(Deserialize, Serialize)]
 pub struct RoomEventRequestBody {
     pub r#type: FriendshipEvent,
     pub message: Option<String>,

--- a/src/components/synapse.rs
+++ b/src/components/synapse.rs
@@ -4,7 +4,9 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{collections::HashMap, time::SystemTime};
 
 use crate::{
-    api::routes::synapse::room_events::{RoomEventRequestBody, RoomEventResponse},
+    api::routes::synapse::room_events::{
+        RoomEventRequestBody, RoomEventResponse, RoomJoinResponse,
+    },
     domain::{error::CommonError, friendship_event::FriendshipEvent},
 };
 
@@ -161,6 +163,19 @@ impl SynapseComponent {
             res.social_user_id = Some(clean_synapse_user_id(&res.user_id));
             res
         })
+    }
+
+    #[tracing::instrument(name = "join room > Synapse components", skip(token))]
+    pub async fn join_room(
+        &self,
+        token: &str,
+        room_id: &str,
+        room_event: FriendshipEvent,
+        room_message_body: Option<&str>,
+    ) -> Result<RoomJoinResponse, CommonError> {
+        let path = format!("/_matrix/client/r0/rooms/{room_id}/join");
+
+        Self::authenticated_post_request(&path, token, &self.synapse_url, {}).await
     }
 
     #[tracing::instrument(name = "put room event > Synapse components", skip(token))]

--- a/src/components/synapse.rs
+++ b/src/components/synapse.rs
@@ -175,7 +175,7 @@ impl SynapseComponent {
     ) -> Result<RoomJoinResponse, CommonError> {
         let path = format!("/_matrix/client/r0/rooms/{room_id}/join");
 
-        Self::authenticated_post_request(&path, token, &self.synapse_url, {}).await
+        Self::authenticated_post_request(&path, token, &self.synapse_url, ()).await
     }
 
     #[tracing::instrument(name = "put room event > Synapse components", skip(token))]

--- a/src/synapse/synapse_handler.rs
+++ b/src/synapse/synapse_handler.rs
@@ -24,6 +24,26 @@ fn build_room_local_alias(acting_user: &str, second_user: &str) -> String {
     addresses.join("+")
 }
 
+/// When accepting a friend request, then the room invitation needs to be accepted too
+pub async fn accept_room_invitation<'a>(
+    token: &str,
+    room_id: &str,
+    room_event: FriendshipEvent,
+    room_message_body: Option<&str>,
+    synapse: &SynapseComponent,
+) -> Result<(), CommonError> {
+    // Check if it's a `accept` event.
+    if room_event != FriendshipEvent::ACCEPT {
+        return Ok(());
+    }
+
+    synapse
+        .join_room(token, room_id, room_event, room_message_body)
+        .await?;
+
+    Ok(())
+}
+
 /// Stores a message event in a Synapse room if it's a friendship request event and the request contains a message.
 pub async fn store_message_in_synapse_room<'a>(
     token: &str,

--- a/src/synapse/synapse_handler.rs
+++ b/src/synapse/synapse_handler.rs
@@ -24,7 +24,7 @@ fn build_room_local_alias(acting_user: &str, second_user: &str) -> String {
     addresses.join("+")
 }
 
-/// When accepting a friend request, then the room invitation needs to be accepted too
+/// When accepting a friend request, then the room invitation needs to be accepted too. Check out [here](https://spec.matrix.org/v1.3/client-server-api/#room-membership) to find out more about room membership and permissions based on the state in which a user may be.
 pub async fn accept_room_invitation<'a>(
     token: &str,
     room_id: &str,

--- a/src/ws/service/friendship_event_updates.rs
+++ b/src/ws/service/friendship_event_updates.rs
@@ -14,8 +14,8 @@ use crate::{
         friendship_status_calculator::get_new_friendship_status,
     },
     synapse::synapse_handler::{
-        get_or_create_synapse_room_id, set_account_data, store_message_in_synapse_room,
-        store_room_event_in_synapse_room,
+        accept_room_invitation, get_or_create_synapse_room_id, set_account_data,
+        store_message_in_synapse_room, store_room_event_in_synapse_room,
     },
     ws::app::SocialContext,
 };
@@ -100,6 +100,16 @@ pub async fn handle_friendship_update(
 
     // If it's a friendship request event and the request contains a message, send a message event to the given room.
     store_message_in_synapse_room(
+        &synapse_token,
+        synapse_room_id.as_str(),
+        new_event,
+        room_message_body,
+        &context.synapse,
+    )
+    .await?;
+
+    // If it's a accepted friendship request event, then the user has to accept the room invitation in synapse.
+    accept_room_invitation(
         &synapse_token,
         synapse_room_id.as_str(),
         new_event,

--- a/src/ws/service/friendship_event_updates.rs
+++ b/src/ws/service/friendship_event_updates.rs
@@ -109,6 +109,7 @@ pub async fn handle_friendship_update(
     .await?;
 
     // If it's a accepted friendship request event, then the user has to accept the room invitation in synapse.
+    // We'll continue storing the room membership update in Synapse to maintain the option to rollback to Matrix without losing any friendship interaction updates
     accept_room_invitation(
         &synapse_token,
         synapse_room_id.as_str(),


### PR DESCRIPTION
Join room in synapse when accepting a friend request according to Synapse Documentation
https://spec.matrix.org/legacy/r0.0.0/client_server.html#post-matrix-client-r0-rooms-roomid-join