### PR TITLE
fix: Join room when sending a request too

### DIFF
--- a/.github/workflows/docker-tag.yml
+++ b/.github/workflows/docker-tag.yml
@@ -1,0 +1,16 @@
+name: Build Docker image
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  cd:
+    uses: decentraland/actions/.github/workflows/build-quay-main.yml@main
+    with:
+      service-name: social-service
+      docker-tag: ${{ github.ref_name }}
+    secrets:
+      QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+      QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}

--- a/src/api/routes/synapse/room_events.rs
+++ b/src/api/routes/synapse/room_events.rs
@@ -37,6 +37,11 @@ pub struct RoomJoinResponse {
 }
 
 #[derive(Deserialize, Serialize)]
+pub struct JoinedRoomsResponse {
+    pub joined_rooms: Vec<String>,
+}
+
+#[derive(Deserialize, Serialize)]
 pub struct RoomEventRequestBody {
     pub r#type: FriendshipEvent,
     pub message: Option<String>,

--- a/src/components/synapse.rs
+++ b/src/components/synapse.rs
@@ -174,7 +174,7 @@ impl SynapseComponent {
     /// https://spec.matrix.org/v1.3/client-server-api/#get_matrixclientv3joined_rooms
     #[tracing::instrument(name = "get joined rooms > Synapse components", skip(token))]
     pub async fn get_joined_rooms(&self, token: &str) -> Result<JoinedRoomsResponse, CommonError> {
-        let path = format!("/_matrix/client/r0/joined_rooms");
+        let path = "/_matrix/client/r0/joined_rooms".to_string();
 
         Self::authenticated_get_request(&path, token, &self.synapse_url).await
     }

--- a/src/components/synapse.rs
+++ b/src/components/synapse.rs
@@ -5,7 +5,7 @@ use std::{collections::HashMap, time::SystemTime};
 
 use crate::{
     api::routes::synapse::room_events::{
-        RoomEventRequestBody, RoomEventResponse, RoomJoinResponse,
+        JoinedRoomsResponse, RoomEventRequestBody, RoomEventResponse, RoomJoinResponse,
     },
     domain::{error::CommonError, friendship_event::FriendshipEvent},
 };
@@ -85,10 +85,11 @@ pub struct SynapseLoginResponse {
     pub well_known: HashMap<String, HashMap<String, String>>,
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Debug)]
 pub struct RoomMember {
     pub state_key: String,
     pub social_user_id: Option<String>, // social_user_id is not present in synapse
+    pub user_id: String,
     pub room_id: String,
     pub r#type: String,
 }
@@ -110,6 +111,11 @@ pub struct CreateRoomOpts {
     pub preset: String,
     pub invite: Vec<String>,
     pub is_direct: bool,
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct InviteUserRequest {
+    pub user_id: String,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -165,6 +171,15 @@ impl SynapseComponent {
         })
     }
 
+    /// https://spec.matrix.org/v1.3/client-server-api/#get_matrixclientv3joined_rooms
+    #[tracing::instrument(name = "get joined rooms > Synapse components", skip(token))]
+    pub async fn get_joined_rooms(&self, token: &str) -> Result<JoinedRoomsResponse, CommonError> {
+        let path = format!("/_matrix/client/r0/joined_rooms");
+
+        Self::authenticated_get_request(&path, token, &self.synapse_url).await
+    }
+
+    /// https://spec.matrix.org/v1.3/client-server-api/#joining-rooms
     #[tracing::instrument(name = "join room > Synapse components", skip(token))]
     pub async fn join_room(
         &self,
@@ -269,6 +284,27 @@ impl SynapseComponent {
         })
     }
 
+    /// https://spec.matrix.org/v1.3/client-server-api/#post_matrixclientv3roomsroomidinvite
+    pub async fn invite_user_to_room(
+        &self,
+        token: &str,
+        room_id: &str,
+        user_id: &str,
+    ) -> Result<(), CommonError> {
+        let encoded_room_id = encode(room_id).to_string();
+        let path = format!("/_matrix/client/r0/rooms/{encoded_room_id}/invite");
+        Self::authenticated_post_request(
+            &path,
+            token,
+            self.synapse_url.as_str(),
+            &InviteUserRequest {
+                user_id: user_id.to_string(),
+            },
+        )
+        .await
+    }
+
+    /// https://spec.matrix.org/v1.3/client-server-api/#creation
     #[tracing::instrument(name = "create_private_room > Synapse components", skip(token))]
     pub async fn create_private_room(
         &self,

--- a/src/components/synapse.rs
+++ b/src/components/synapse.rs
@@ -185,8 +185,6 @@ impl SynapseComponent {
         &self,
         token: &str,
         room_id: &str,
-        room_event: FriendshipEvent,
-        room_message_body: Option<&str>,
     ) -> Result<RoomJoinResponse, CommonError> {
         let encoded_room_id = encode(room_id).to_string();
         let path = format!("/_matrix/client/r0/rooms/{encoded_room_id}/join");

--- a/src/components/synapse.rs
+++ b/src/components/synapse.rs
@@ -284,26 +284,6 @@ impl SynapseComponent {
         })
     }
 
-    /// https://spec.matrix.org/v1.3/client-server-api/#post_matrixclientv3roomsroomidinvite
-    pub async fn invite_user_to_room(
-        &self,
-        token: &str,
-        room_id: &str,
-        user_id: &str,
-    ) -> Result<(), CommonError> {
-        let encoded_room_id = encode(room_id).to_string();
-        let path = format!("/_matrix/client/r0/rooms/{encoded_room_id}/invite");
-        Self::authenticated_post_request(
-            &path,
-            token,
-            self.synapse_url.as_str(),
-            &InviteUserRequest {
-                user_id: user_id.to_string(),
-            },
-        )
-        .await
-    }
-
     /// https://spec.matrix.org/v1.3/client-server-api/#creation
     #[tracing::instrument(name = "create_private_room > Synapse components", skip(token))]
     pub async fn create_private_room(

--- a/src/synapse/synapse_handler.rs
+++ b/src/synapse/synapse_handler.rs
@@ -29,8 +29,6 @@ fn build_room_local_alias(acting_user: &str, second_user: &str) -> String {
 pub async fn accept_room_invitation<'a>(
     token: &str,
     room_id: &str,
-    room_event: FriendshipEvent,
-    room_message_body: Option<&str>,
     synapse: &SynapseComponent,
 ) -> Result<(), CommonError> {
     let joined_rooms = synapse.get_joined_rooms(token).await;
@@ -38,9 +36,7 @@ pub async fn accept_room_invitation<'a>(
         Ok(rooms) => {
             if !rooms.joined_rooms.contains(&room_id.to_string()) {
                 // The room exists of a previous interaction between users, but the current user hasn't joined yet
-                let joined_room = synapse
-                    .join_room(token, room_id, room_event, room_message_body)
-                    .await;
+                let joined_room = synapse.join_room(token, room_id).await;
                 joined_room.map(|_| ())
             } else {
                 Ok(())

--- a/src/synapse/synapse_handler.rs
+++ b/src/synapse/synapse_handler.rs
@@ -38,7 +38,7 @@ pub async fn accept_room_invitation<'a>(
             if !rooms.joined_rooms.contains(&room_id.to_string()) {
                 // The room exists of a previous interaction between users, but the current user hasn't joined yet
                 let joined_room = synapse
-                    .join_room(token, &room_id, room_event, room_message_body)
+                    .join_room(token, room_id, room_event, room_message_body)
                     .await;
                 match joined_room {
                     Ok(_) => Ok(()),

--- a/src/synapse/synapse_handler.rs
+++ b/src/synapse/synapse_handler.rs
@@ -24,7 +24,8 @@ fn build_room_local_alias(acting_user: &str, second_user: &str) -> String {
     addresses.join("+")
 }
 
-/// When accepting a friend request, then the room invitation needs to be accepted too. Check out [here](https://spec.matrix.org/v1.3/client-server-api/#room-membership) to find out more about room membership and permissions based on the state in which a user may be.
+/// When interacting with a friend, then you need to join the room if you hadn't joined it yet.
+/// Check out [here](https://spec.matrix.org/v1.3/client-server-api/#room-membership) to find out more about room membership and permissions based on the state in which a user may be.
 pub async fn accept_room_invitation<'a>(
     token: &str,
     room_id: &str,

--- a/src/synapse/synapse_handler.rs
+++ b/src/synapse/synapse_handler.rs
@@ -24,37 +24,6 @@ fn build_room_local_alias(acting_user: &str, second_user: &str) -> String {
     addresses.join("+")
 }
 
-pub async fn invite_other_if_needed<'a>(
-    token: &str,
-    room_id: &str,
-    synapse_other_user_id: &str,
-    synapse: &SynapseComponent,
-) -> Result<(), CommonError> {
-    // Get room members
-    let room_members = synapse.get_room_members(token, room_id).await;
-    match room_members {
-        Ok(response) => {
-            let exists = response
-                .chunk
-                .iter()
-                .find(|x| x.user_id == synapse_other_user_id);
-            match exists {
-                Some(m) => Ok(()),
-                None => {
-                    let invite_response = synapse
-                        .invite_user_to_room(token, room_id, synapse_other_user_id)
-                        .await;
-                    match invite_response {
-                        Ok(_) => Ok(()),
-                        Err(err) => Err(err),
-                    }
-                }
-            }
-        }
-        Err(err) => Err(err),
-    }
-}
-
 /// When accepting a friend request, then the room invitation needs to be accepted too. Check out [here](https://spec.matrix.org/v1.3/client-server-api/#room-membership) to find out more about room membership and permissions based on the state in which a user may be.
 pub async fn accept_room_invitation<'a>(
     token: &str,

--- a/src/ws/service/friendship_event_updates.rs
+++ b/src/ws/service/friendship_event_updates.rs
@@ -51,14 +51,7 @@ pub async fn handle_friendship_update(
     let room_message_body = event_payload.request_event_message_body.as_deref();
 
     // The room may exists but maybe the current user hasn't joined it yet.
-    accept_room_invitation(
-        &synapse_token,
-        synapse_room_id.as_str(),
-        new_event,
-        room_message_body,
-        &context.synapse,
-    )
-    .await?;
+    accept_room_invitation(&synapse_token, synapse_room_id.as_str(), &context.synapse).await?;
 
     set_account_data(
         &synapse_token,

--- a/tests/routes/matrix/room_events.rs
+++ b/tests/routes/matrix/room_events.rs
@@ -41,12 +41,14 @@ mod tests {
                     r#type: "".to_string(),
                     state_key: room_members.0,
                     social_user_id: None,
+                    user_id: "".to_string(),
                 },
                 RoomMember {
                     room_id: "a_room_id".to_string(),
                     r#type: "".to_string(),
                     state_key: room_members.1,
                     social_user_id: None,
+                    user_id: "".to_string(),
                 },
             ],
         };


### PR DESCRIPTION
This PR solves a corner case when the matrix room already existed but one of the members didn't join. For example:
1. User A sends a friend request to User B: this creates a room in Matrix, where A is a member and sends an invite to B.
2. User A cancels the friend request (nothing is done in Matrix)
3. User B sends a friend request to User A: He needs to join the room first, as it already exists