### PR TITLE
fix: use debian11 as rust base docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust as builder
+FROM rust:1.71.1 as builder
 COPY . /app
 WORKDIR /app
 RUN apt update && apt-get install -y protobuf-compiler


### PR DESCRIPTION
Using the latest version of the Rust docker base image resulted in using Debian 12 while the run image was still using Debian 11 and that ended up in being unable to solve dependencies that required different versions